### PR TITLE
feat(tv-tauri): add Linux X11/XWayland desktop playback

### DIFF
--- a/apps/tv-tauri/src-tauri/Cargo.lock
+++ b/apps/tv-tauri/src-tauri/Cargo.lock
@@ -22,7 +22,10 @@ name = "airwave"
 version = "0.12.12"
 dependencies = [
  "futures",
+ "gdkx11",
+ "gtk",
  "if-addrs",
+ "libc",
  "log",
  "objc2",
  "objc2-app-kit",

--- a/apps/tv-tauri/src-tauri/Cargo.toml
+++ b/apps/tv-tauri/src-tauri/Cargo.toml
@@ -37,13 +37,24 @@ tauri-plugin-updater = "2"
 # Relaunch the app after an update installs.
 tauri-plugin-process = "2"
 tauri-plugin-os = "2"
-# The native window handle (mpv `--wid` embed) + per-platform windowing.
+# The native window handle (mpv `--wid` embed on Win32 and Linux/X11) + per-platform windowing.
 raw-window-handle = "0.6"
 # Enumerate LAN interfaces natively for onboarding's server scan — the webview's WebRTC
 # subnet trick (tv-web) gets mDNS-obfuscated inside WebView2, so we read interfaces in Rust.
 if-addrs = "0.13"
 # Concurrent health probes in the server scan. reqwest comes from tauri-plugin-http (re-exported).
 futures = "0.3"
+
+# libmpv requires the process-wide numeric locale to be exactly `C` when its
+# client context is created. GTK applies the desktop locale before Tauri's
+# setup callback, so reset LC_NUMERIC through libc immediately before
+# `mpv_create()` on Linux.
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
+# Put libmpv in a dedicated GTK/X11 host underneath WebKitGTK. Passing the
+# top-level window XID lets mpv's child window cover the webview on X11.
+gtk = "0.18"
+gdkx11 = "0.18"
 
 # Windows: Win32 for the child-HWND video surface + WS_CLIPCHILDREN + resize.
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/apps/tv-tauri/src-tauri/build.rs
+++ b/apps/tv-tauri/src-tauri/build.rs
@@ -34,6 +34,13 @@ fn main() {
 
     println!("cargo:rustc-link-search=native={}", lib_dir.display());
 
+    // Linux creates a dedicated X11 child below WebKitGTK for libmpv's `wid`.
+    // The gtk/gdk link set does not expose the Xlib symbols used to create and
+    // resize that child, so link the X11 client library explicitly.
+    if target_os == "linux" {
+        println!("cargo:rustc-link-lib=X11");
+    }
+
     // macOS: the runtime ships as `libmpv.2.dylib` (soname) but the linker wants `libmpv.dylib` for
     // `-l mpv`. Create the dev symlink if missing. Add rpaths: the vendor lib dir (so `cargo run` finds
     // the dylibs in dev) + `@executable_path/../Frameworks` (the bundled `.app`, where the bundling step

--- a/apps/tv-tauri/src-tauri/src/lib.rs
+++ b/apps/tv-tauri/src-tauri/src/lib.rs
@@ -1,4 +1,6 @@
 mod mpv;
+#[cfg(target_os = "linux")]
+mod render_linux;
 #[cfg(target_os = "macos")]
 mod render_macos;
 
@@ -54,11 +56,39 @@ fn mpv_stop(mpv: State<'_, Arc<mpv::Mpv>>) -> Result<(), String> {
     mpv.command(&["stop"])
 }
 
-/// Render the video into a sub-rectangle of the window — the guide's featured-panel slot — for the
-/// MINI FEED. The single full-window mpv surface stays put; `video-margin-ratio-*` scales the video
-/// into `(x,y,w,h)` (physical px within a `win_w`×`win_h` window). The guide punches only that slot
-/// transparent, so the positioned video shows there and the black margins are covered by the opaque
-/// guide. No child HWND, so no airspace problem — it builds on the proven full-window compositing.
+fn clear_video_margins(mpv: &mpv::Mpv) -> Result<(), String> {
+    for p in [
+        "video-margin-ratio-left",
+        "video-margin-ratio-right",
+        "video-margin-ratio-top",
+        "video-margin-ratio-bottom",
+    ] {
+        mpv.set_property_double(p, 0.0)?;
+    }
+    Ok(())
+}
+
+/// Linux native airspace must physically occupy only the mini-player slot;
+/// WebKitGTK cannot cover a full-size X11 video child with the guide.
+#[cfg(target_os = "linux")]
+#[tauri::command]
+fn mpv_set_region(
+    mpv: State<'_, Arc<mpv::Mpv>>,
+    host: State<'_, Arc<render_linux::LinuxVideoHost>>,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    win_w: f64,
+    win_h: f64,
+) -> Result<(), String> {
+    clear_video_margins(&mpv)?;
+    host.show_region(x, y, w, h, win_w, win_h)
+}
+
+/// Windows/macOS keep one full-window render surface and position the mini
+/// video inside it with mpv margins; their compositor can paint UI above it.
+#[cfg(not(target_os = "linux"))]
 #[tauri::command]
 fn mpv_set_region(
     mpv: State<'_, Arc<mpv::Mpv>>,
@@ -81,17 +111,38 @@ fn mpv_set_region(
     Ok(())
 }
 
-/// Reset the video to fill the whole window (fullscreen player) — clears the mini-feed margins.
+/// Full player: reset mpv margins and map the Linux native host across the
+/// content area. `win_w`/`win_h` are CSS pixels (XWayland uses the same space).
+#[cfg(target_os = "linux")]
 #[tauri::command]
-fn mpv_fill_window(mpv: State<'_, Arc<mpv::Mpv>>) -> Result<(), String> {
-    for p in [
-        "video-margin-ratio-left",
-        "video-margin-ratio-right",
-        "video-margin-ratio-top",
-        "video-margin-ratio-bottom",
-    ] {
-        mpv.set_property_double(p, 0.0)?;
-    }
+fn mpv_fill_window(
+    mpv: State<'_, Arc<mpv::Mpv>>,
+    host: State<'_, Arc<render_linux::LinuxVideoHost>>,
+    win_w: f64,
+    win_h: f64,
+) -> Result<(), String> {
+    clear_video_margins(&mpv)?;
+    host.show_region(0.0, 0.0, win_w, win_h, win_w, win_h)
+}
+
+#[cfg(not(target_os = "linux"))]
+#[tauri::command]
+fn mpv_fill_window(mpv: State<'_, Arc<mpv::Mpv>>, win_w: f64, win_h: f64) -> Result<(), String> {
+    let _ = (win_w, win_h);
+    clear_video_margins(&mpv)
+}
+
+/// Hide native video completely while stopped or while a non-guide route is
+/// covering mini playback. Non-Linux render paths do not need a native unmap.
+#[cfg(target_os = "linux")]
+#[tauri::command]
+fn mpv_hide_window(host: State<'_, Arc<render_linux::LinuxVideoHost>>) -> Result<(), String> {
+    host.hide()
+}
+
+#[cfg(not(target_os = "linux"))]
+#[tauri::command]
+fn mpv_hide_window() -> Result<(), String> {
     Ok(())
 }
 
@@ -432,6 +483,7 @@ pub fn run() {
             mpv_stop,
             mpv_set_region,
             mpv_fill_window,
+            mpv_hide_window,
             prepare_window_for_fullscreen
         ])
         .setup(|app| {
@@ -463,8 +515,9 @@ fn setup_player(app: &mut tauri::App) -> Result<(), String> {
         .ok_or("no main window")?;
 
     // Transparent webview so the video composites behind the UI (Windows: WebView2/DComp over the
-    // child HWND; macOS: transparent WKWebView over the Metal layer). NOT window transparency on
-    // Windows; on macOS the window itself is transparent (tauri.macos.conf `transparent: true`).
+    // child HWND; Linux: WebKitGTK over a dedicated GTK/X11 host; macOS: WKWebView over the Metal layer).
+    // The Linux/macOS platform configs also create the native window as transparent; Windows keeps
+    // the window itself opaque and only makes the webview transparent.
     let _ = window.set_background_color(Some(tauri::utils::config::Color(0, 0, 0, 0)));
 
     // macOS: extend the webview content under a transparent titlebar so the NATIVE traffic lights
@@ -477,9 +530,9 @@ fn setup_player(app: &mut tauri::App) -> Result<(), String> {
     let mpv = Arc::new(mpv::Mpv::new()?);
     mpv.set_option_string("hwdec", "auto")?; // hardware decode (soia baseline)
 
-    // Video attach is per-platform. Windows/Linux: mpv renders itself into a native surface passed as
-    // `wid` (Windows = the main window HWND under the WebView2 DComp visual) — a pre-init option. macOS:
-    // mpv 0.41 has no embed window context (cocoa/macvk make their own window — see
+    // Video attach is per-platform. Windows/Linux: mpv renders itself into a native surface passed
+    // as `wid` (Windows = HWND; Linux = dedicated GTK drawing-area XID) — a pre-init option. macOS: mpv 0.41 has no embed
+    // window context (cocoa/macvk make their own window — see
     // project-tv-tauri-macos-render), so we use the RENDER API: `vo=libmpv`, then create + drive an
     // OpenGL render context into a view behind the transparent webview.
     #[cfg(target_os = "macos")]
@@ -497,10 +550,22 @@ fn setup_player(app: &mut tauri::App) -> Result<(), String> {
     }
     #[cfg(not(target_os = "macos"))]
     {
+        #[cfg(target_os = "windows")]
         let wid = resolve_video_wid(&window)?;
+        #[cfg(target_os = "linux")]
+        let linux_host = Arc::new(render_linux::setup(&window)?);
+        #[cfg(target_os = "linux")]
+        let wid = linux_host.xid();
         mpv.set_option_i64("wid", wid)?;
+        // A Wayland desktop still exports WAYLAND_DISPLAY while this window is running through
+        // XWayland. Keep libmpv on an X11 context too, otherwise its automatic probe can select a
+        // native Wayland context that cannot attach to the XID. Prefer EGL, with GLX as fallback.
+        #[cfg(target_os = "linux")]
+        mpv.set_option_string("gpu-context", "x11egl,x11")?;
         mpv.initialize()?;
         log::info!("mpv attached (wid={wid})");
+        #[cfg(target_os = "linux")]
+        app.manage(linux_host);
     }
 
     // mpv stays IDLE (attached, initialized, ready) — no autoplay. The watch route drives it via the
@@ -518,6 +583,7 @@ fn setup_player(app: &mut tauri::App) -> Result<(), String> {
 
 /// Resolve the native surface mpv renders into (`--wid`), per platform.
 ///  - **Windows:** the main window's HWND (video is a child HWND under the WebView2 DComp visual).
+///  - **Linux:** handled by `render_linux`: a dedicated GTK drawing-area XID below WebKitGTK.
 ///  - **macOS:** a **CAMetalLayer** inserted as sublayer 0 of the window's contentView (behind the
 ///    transparent WKWebView), returned as its pointer — mpv accepts a CAMetalLayer\* as `wid`
 ///    (soia's open layer-setup + plezy's `wid` attach). Must be called on the main thread.
@@ -529,7 +595,7 @@ fn resolve_video_wid(window: &tauri::WebviewWindow) -> Result<i64, String> {
     }
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 fn resolve_video_wid(_window: &tauri::WebviewWindow) -> Result<i64, String> {
     Err("video render-attach not implemented on this platform yet".into())
 }

--- a/apps/tv-tauri/src-tauri/src/main.rs
+++ b/apps/tv-tauri/src-tauri/src/main.rs
@@ -1,6 +1,46 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+/// mpv's `wid` embedding API needs an X11 window id. Select GTK's X11 backend before Tauri/GTK is
+/// initialized; on a Wayland desktop this makes the app use XWayland while preserving the native
+/// Wayland session for every other application.
+#[cfg(target_os = "linux")]
+fn configure_linux_display_backend() {
+    if std::env::var_os("DISPLAY").is_none() {
+        eprintln!(
+            "Airwave requires an X11 display for embedded video. Native Wayland is not supported by \
+             mpv --wid; enable XWayland and ensure DISPLAY is set."
+        );
+        std::process::exit(1);
+    }
+
+    let wayland_session = std::env::var_os("WAYLAND_DISPLAY").is_some();
+    let requested_backend = std::env::var_os("GDK_BACKEND");
+    if requested_backend.as_deref() != Some(std::ffi::OsStr::new("x11")) {
+        if let Some(backend) = requested_backend {
+            eprintln!(
+                "Airwave: overriding GDK_BACKEND={} with x11 for libmpv embedding.",
+                backend.to_string_lossy()
+            );
+        } else if wayland_session {
+            eprintln!("Airwave: Wayland session detected; using XWayland for libmpv embedding.");
+        }
+
+        std::env::set_var("GDK_BACKEND", "x11");
+    }
+
+    // WebKitGTK's DMA-BUF renderer can try to allocate GBM buffers for the XWayland window and
+    // fail on otherwise valid Wayland/driver combinations. Force its shared-memory transport,
+    // which keeps accelerated compositing and the transparent UI without using the GBM path.
+    // Honor an explicit user value so DMA-BUF can still be tested on known-good systems.
+    if wayland_session && std::env::var_os("WEBKIT_DMABUF_RENDERER_FORCE_SHM").is_none() {
+        std::env::set_var("WEBKIT_DMABUF_RENDERER_FORCE_SHM", "1");
+    }
+}
+
 fn main() {
-  app_lib::run();
+    #[cfg(target_os = "linux")]
+    configure_linux_display_backend();
+
+    app_lib::run();
 }

--- a/apps/tv-tauri/src-tauri/src/mpv/mod.rs
+++ b/apps/tv-tauri/src-tauri/src/mpv/mod.rs
@@ -15,14 +15,37 @@ use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int, c_void};
 use std::ptr;
 use std::sync::atomic::{AtomicPtr, Ordering};
+#[cfg(target_os = "linux")]
+use std::sync::OnceLock;
 
 pub use ffi::MpvFormat;
-pub use ffi::{MPV_EVENT_END_FILE, MPV_EVENT_FILE_LOADED, MPV_EVENT_PROPERTY_CHANGE, MPV_EVENT_SHUTDOWN};
+pub use ffi::{
+    MPV_EVENT_END_FILE, MPV_EVENT_FILE_LOADED, MPV_EVENT_PROPERTY_CHANGE, MPV_EVENT_SHUTDOWN,
+};
 
 /// Owns a libmpv context. `Send`/`Sync`: libmpv's client API is thread-safe for
 /// the calls we make, and the context is guarded by an atomic pointer.
 pub struct Mpv {
     ctx: AtomicPtr<c_void>,
+}
+
+#[cfg(target_os = "linux")]
+fn ensure_c_numeric_locale() -> Result<(), String> {
+    static RESULT: OnceLock<Result<(), String>> = OnceLock::new();
+
+    RESULT
+        .get_or_init(|| {
+            const C_LOCALE: &[u8] = b"C\0";
+            let locale = unsafe {
+                libc::setlocale(libc::LC_NUMERIC, C_LOCALE.as_ptr().cast::<libc::c_char>())
+            };
+            if locale.is_null() {
+                Err("failed to set LC_NUMERIC=C before creating libmpv".into())
+            } else {
+                Ok(())
+            }
+        })
+        .clone()
 }
 
 unsafe impl Send for Mpv {}
@@ -33,9 +56,18 @@ impl Mpv {
     /// Call [`Mpv::set_option_string`] for pre-init options BEFORE this if
     /// needed; here we set them then `mpv_initialize`.
     pub fn new() -> Result<Self, String> {
+        // GTK initializes the process locale from the desktop before Tauri's setup callback.
+        // libmpv deliberately refuses to create a client unless LC_NUMERIC is exactly `C`
+        // (C.UTF-8 is not accepted), so reset only that category immediately before mpv_create.
+        #[cfg(target_os = "linux")]
+        ensure_c_numeric_locale()?;
+
         let ctx = unsafe { ffi::mpv_create() };
         if ctx.is_null() {
-            return Err("mpv_create() returned null (libmpv missing or LC_NUMERIC not C)".into());
+            #[cfg(target_os = "linux")]
+            return Err("mpv_create() returned null after setting LC_NUMERIC=C".into());
+            #[cfg(not(target_os = "linux"))]
+            return Err("mpv_create() returned null (libmpv missing or invalid runtime)".into());
         }
         let mpv = Mpv {
             ctx: AtomicPtr::new(ctx),

--- a/apps/tv-tauri/src-tauri/src/render_linux.rs
+++ b/apps/tv-tauri/src-tauri/src/render_linux.rs
@@ -1,0 +1,116 @@
+//! Linux X11 host for libmpv.
+//!
+//! Keep mpv in a dedicated child beneath WebKitGTK so transparent video areas
+//! reveal it while HTML chrome remains visible and interactive. The child is
+//! unmapped while idle, fills the content area for full playback, and moves to
+//! the featured-panel aperture for mini playback without changing Tauri's GTK
+//! widget hierarchy.
+
+use gdkx11::x11::xlib;
+use gtk::glib::translate::ToGlibPtr;
+use gtk::prelude::*;
+pub struct LinuxVideoHost {
+    display: usize,
+    parent_xid: xlib::Window,
+    xid: xlib::Window,
+}
+
+// The X server reclaims this child when GTK closes its display connection.
+// Destroying it from `Drop` would race both GTK teardown and mpv's final use of
+// the `wid`, whose state-drop order is intentionally not relied upon here.
+
+impl LinuxVideoHost {
+    pub fn xid(&self) -> i64 {
+        self.xid as i64
+    }
+
+    pub fn show_region(
+        &self,
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+        win_w: f64,
+        win_h: f64,
+    ) -> Result<(), String> {
+        let display = self.display;
+        let parent_xid = self.parent_xid;
+        let xid = self.xid;
+        gtk::glib::idle_add_once(move || unsafe {
+            let display = display as *mut xlib::Display;
+            let mut parent: xlib::XWindowAttributes = std::mem::zeroed();
+            if xlib::XGetWindowAttributes(display, parent_xid, &mut parent) == 0 {
+                log::error!("failed to read Linux video parent geometry");
+                return;
+            }
+
+            // Browser geometry arrives in CSS pixels while Xlib uses the
+            // realized parent-window coordinate space. Deriving the ratio on
+            // every move handles GDK scaling and monitor changes without
+            // assuming a fixed devicePixelRatio.
+            let scale_x = f64::from(parent.width.max(1)) / win_w.max(1.0);
+            let scale_y = f64::from(parent.height.max(1)) / win_h.max(1.0);
+            xlib::XMoveResizeWindow(
+                display,
+                xid,
+                (x.max(0.0) * scale_x).round() as i32,
+                (y.max(0.0) * scale_y).round() as i32,
+                (w.max(1.0) * scale_x).round().max(1.0) as u32,
+                (h.max(1.0) * scale_y).round().max(1.0) as u32,
+            );
+            xlib::XMapWindow(display, xid);
+            // Keep WebKitGTK above the video host so its transparent video
+            // aperture reveals mpv while HTML chrome remains interactive.
+            xlib::XLowerWindow(display, xid);
+            xlib::XFlush(display);
+        });
+        Ok(())
+    }
+
+    pub fn hide(&self) -> Result<(), String> {
+        let display = self.display;
+        let xid = self.xid;
+        gtk::glib::idle_add_once(move || unsafe {
+            let display = display as *mut xlib::Display;
+            xlib::XUnmapWindow(display, xid);
+            xlib::XFlush(display);
+        });
+        Ok(())
+    }
+}
+
+/// Create, but deliberately do not map, the X11 parent passed to libmpv.
+pub fn setup(window: &tauri::WebviewWindow) -> Result<LinuxVideoHost, String> {
+    let gtk_window = window.gtk_window().map_err(|e| e.to_string())?;
+    let gdk_window = gtk_window
+        .window()
+        .ok_or("Tauri GTK window is not realized")?;
+    let x11_parent = gdk_window
+        .downcast::<gdkx11::X11Window>()
+        .map_err(|_| "Tauri window is not using X11 (GDK_BACKEND must be x11)".to_string())?;
+    let parent_xid = x11_parent.xid();
+
+    let gdk_display = gtk::gdk::Display::default().ok_or("GDK has no default display")?;
+    let x11_display = gdk_display
+        .downcast::<gdkx11::X11Display>()
+        .map_err(|_| "Tauri display is not using X11 (GDK_BACKEND must be x11)".to_string())?;
+    let display =
+        unsafe { gdkx11::ffi::gdk_x11_display_get_xdisplay(x11_display.to_glib_none().0) };
+    if display.is_null() {
+        return Err("GDK returned a null X11 display".into());
+    }
+
+    // Start at 1x1 and unmapped. The frontend explicitly shows the host when
+    // entering full/mini playback and hides it again for guide-only routes.
+    let xid = unsafe { xlib::XCreateSimpleWindow(display, parent_xid, 0, 0, 1, 1, 0, 0, 0) };
+    if xid == 0 {
+        return Err("failed to create the Linux mpv X11 host window".into());
+    }
+    unsafe { xlib::XFlush(display) };
+
+    Ok(LinuxVideoHost {
+        display: display as usize,
+        parent_xid,
+        xid,
+    })
+}

--- a/apps/tv-tauri/src-tauri/tauri.linux.conf.json
+++ b/apps/tv-tauri/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "title": "Airwave",
+        "width": 1280,
+        "height": 720,
+        "minWidth": 960,
+        "minHeight": 540,
+        "resizable": true,
+        "center": true,
+        "fullscreen": false,
+        "decorations": false,
+        "transparent": true
+      }
+    ]
+  }
+}

--- a/apps/tv-tauri/src/features/watch/mpv.ts
+++ b/apps/tv-tauri/src/features/watch/mpv.ts
@@ -18,11 +18,13 @@ export const mpv = {
   stop: () => invoke("mpv_stop"),
   setAudioTrack: (aid: string) => invoke("mpv_set_audio_track", { aid }),
   setSubtitleTrack: (sid: string) => invoke("mpv_set_subtitle_track", { sid }),
-  /** Mini feed: render the video into a sub-rect `(x,y,w,h)` of a `winW`×`winH` window (CSS px — the
-   *  ratio is DPR-independent) via mpv `video-margin-ratio`. `fillWindow` clears it (fullscreen). */
+  /** Mini feed: render the video into a sub-rect `(x,y,w,h)` of a `winW`×`winH` window. */
   setRegion: (x: number, y: number, w: number, h: number, winW: number, winH: number) =>
     invoke("mpv_set_region", { x, y, w, h, winW, winH }),
-  fillWindow: () => invoke("mpv_fill_window"),
+  fillWindow: (winW = window.innerWidth, winH = window.innerHeight) =>
+    invoke("mpv_fill_window", { winW, winH }),
+  /** Linux unmaps native video while the guide-only UI is visible; a no-op elsewhere. */
+  hideWindow: () => invoke("mpv_hide_window"),
 };
 
 export type MpvLoaded = { width: number; height: number; duration: number };

--- a/apps/tv-tauri/src/features/watch/player-context.tsx
+++ b/apps/tv-tauri/src/features/watch/player-context.tsx
@@ -145,16 +145,27 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (layout === "full") {
-      void mpv.fillWindow();
+      void mpv.fillWindow(window.innerWidth, window.innerHeight);
     } else if (layout === "mini" && onGuide) {
       // Re-runs when returning to the guide (onGuide flips true) so mpv re-docks into the slot.
       syncMini();
+    } else if (layout === "mini") {
+      // Linux video is native airspace, so remove it while another route is in front.
+      void mpv.hideWindow();
     } else if (layout === "off") {
       setMiniRect(null);
-      void mpv.fillWindow(); // reset margins (mpv is stopped in `off`)
+      void mpv.hideWindow();
     }
-    // layout === "mini" && !onGuide: leave mpv where it is (covered by the route's opaque page).
   }, [layout, onGuide, syncMini]);
+
+  // The Linux video host is a real native child, so keep full playback sized to
+  // the webview when the user resizes/maximizes the window.
+  useEffect(() => {
+    if (layout !== "full") return;
+    const on = () => void mpv.fillWindow(window.innerWidth, window.innerHeight);
+    window.addEventListener("resize", on);
+    return () => window.removeEventListener("resize", on);
+  }, [layout]);
 
   // Keep the mini feed glued to the slot as the window/guide reflows.
   useEffect(() => {
@@ -225,7 +236,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
         ))}
 
       {/* The routed content (guide). Hidden when full so mpv fills the window. */}
-      <div style={{ position: "absolute", inset: 0, opacity: hidden ? 0 : 1, pointerEvents: hidden ? "none" : "auto" }}>
+      <div style={{ position: "absolute", inset: 0, zIndex: 1, opacity: hidden ? 0 : 1, pointerEvents: hidden ? "none" : "auto" }}>
         {children}
       </div>
 


### PR DESCRIPTION
## What & why

Adds an initial Linux implementation for the Tauri TV/desktop viewer (`apps/tv-tauri`). Linux was the remaining no-op desktop target because libmpv `wid` embedding needed a native surface that could coexist with WebKitGTK.

This change:

- creates a dedicated X11 child window for libmpv instead of drawing into the GTK toplevel;
- keeps that child below the transparent webview so HTML player chrome remains interactive;
- moves and scales the child between full playback and the guide mini-player aperture;
- derives X11 geometry from the realized parent size, including display-scale changes;
- selects XWayland when launched from a Wayland session because mpv `wid` requires an XID;
- forces libmpv-compatible `LC_NUMERIC=C` before `mpv_create()`;
- avoids changing Tauri's GTK widget hierarchy, which also avoids the undecorated-resize panic seen with wrapper-widget approaches.

The server, scheduling, database, Docker, and release-packaging paths are intentionally untouched. Native Wayland is not implemented; Linux currently requires X11 or XWayland with `DISPLAY` set.

## Area

- [ ] Server / admin (backend, channels, scheduling, AI lineup, imports)
- [x] A TV / player client (Apple TV, Fire TV, Android TV, Roku, webOS, tv-web)
- [ ] Desktop server app (Windows / macOS / Linux)
- [ ] Docs / website (getairwave.tv)
- [ ] CI / tooling

## Testing

- `cargo check --locked`
- `tsc --noEmit` for `apps/tv-tauri`
- Vite production build for `apps/tv-tauri`
- `tauri build --no-bundle` on x86_64 CachyOS
- Manual Linux/XWayland validation of startup, libmpv attachment, full playback, and guide mini-player behavior on the implementation this was extracted from

This is opened as a draft so the final beneath-WebKit stacking behavior can receive another visual pass before merge.

## Checklist

- [x] Typechecks / builds locally (`pnpm check-types`, relevant `build`)
- [x] I did **not** bump versions or tag (maintainer handles releases)
- [x] No secrets, certs, or `.env` values committed
