### PR TITLE
tv-native: async mpv client API — fix tvOS main-thread deadlock (#30) + player observability (#31)

### DIFF
--- a/.claude/skills/version-bump/skill.md
+++ b/.claude/skills/version-bump/skill.md
@@ -31,17 +31,33 @@ If the user just says "do a version bump" with no tier, infer it from the diff:
 **Exactly three segments. Never a fourth** (no `0.6.7.1`). If a patch grows too big, ship the
 full scope under its `x.y.z`, or roll the leftover into the NEXT `x.y.z` — never a sub-version.
 
-## Workspaces in lockstep
+## The bump command (use this — don't hand-edit)
 
-Bump **every shippable app** under `apps/*` to the same version (discover them; don't assume a
-fixed list — apps are added over time: server, admin web, tv-webos, and later tv clients).
-Internal `packages/*` workspace libraries are NOT versioned externally and stay at `0.0.0`.
-The root `package.json` is not part of the lockstep bump.
+**Do the mechanical file edits with `pnpm version:bump` (`scripts/bump-version.ts`), not by hand:**
 
-No `v` prefix in `package.json` (`"version": "1.1.0"`, not `"v1.1.0"`).
+```
+pnpm version:bump <patch|minor|major|X.Y.Z> [--dry-run]
+```
 
-**ALSO bump these NON-`package.json` version files in the same lockstep** — they feed store manifests /
-About pages and silently drift stale if missed (each has burned us once):
+It sets **every** version file in lockstep with TARGETED edits — all `apps/*/package.json` (discovered, not
+hardcoded), plus `apps/tv-web/public/appinfo.json`, `apps/tv-native/app.json`,
+`apps/tv-tauri/src-tauri/{tauri.conf.json, Cargo.toml, Cargo.lock}`, and `apps/tv-roku/manifest`. The
+`airwave` line in the Cargo files is found via its `name = "airwave"` anchor, so a dependency crate can
+**never** be bumped by accident (this is why the script exists — see the Cargo.lock footgun below). It
+**refuses to run** if the version files are out of sync (surfaces the mismatch instead of normalizing), and
+`--dry-run` previews every file without writing.
+
+The script edits version files ONLY. **You still** write the CHANGELOG entry, commit, and push (and never
+`git tag` unless James says so). Prefer the script over manual/`sed` edits every time.
+
+## Workspaces in lockstep (what the script touches — reference)
+
+Every shippable app under `apps/*` bumps to the same version (the script discovers them; apps are added over
+time). Internal `packages/*` stay at `0.0.0`. The root `package.json` is not bumped. No `v` prefix in
+`package.json` (`"version": "1.1.0"`, not `"v1.1.0"`).
+
+These NON-`package.json` version files are bumped in the same lockstep (the script handles them) — they feed
+store manifests / About pages and silently drift stale if missed (each has burned us once):
 - `apps/tv-native/app.json` → `expo.version` (Expo app version + `Constants.expoConfig.version` About page).
 - `apps/tv-web/public/appinfo.json` → `version` (the **webOS** app manifest; required for the `.ipk`
   build + store submission, read at runtime by `webOSTV.js`). Do NOT delete this file.
@@ -50,16 +66,18 @@ About pages and silently drift stale if missed (each has burned us once):
 - `apps/tv-roku/manifest` → `major_version` / `minor_version` / `build_version` (e.g. `0.12.3` →
   `major_version=0`, `minor_version=12`, `build_version=3`) + the `Mirrors package.json <ver>` comment.
 
-After bumping, verify they all match `apps/*/package.json` before committing.
+The script keeps them all in sync automatically; if you ever edit by hand, verify they all match
+`apps/*/package.json` before committing.
 
 ## Instructions
 
 1. **Read `CHANGELOG.md`** to find the most recent version (top entry). If it doesn't exist
    yet, this is the first release — create it starting at the current app version.
 2. **Determine the new version** from the requested tier and the previous version.
-3. **Read each shippable `apps/*/package.json`** and verify they all agree on the previous
-   version. If they're out of sync, STOP and tell James — the mismatch may be intentional or
-   signal a botched prior bump. Do not silently normalize.
+3. **Confirm the current version + sync** by running `pnpm version:bump <tier> --dry-run`. It prints the
+   `current → next` and every file it would touch, and **refuses to run if the files are out of sync** (it
+   surfaces the mismatch). If it reports a mismatch, STOP and tell James — it may be intentional or a botched
+   prior bump. Do not silently normalize.
 4. **Inspect the staged + unstaged diff** (`git status`, `git diff`, `git diff --staged`) to
    understand what's actually shipping. Do not write the entry from the narrative alone.
 5. **Draft the `## [X.Y.Z] - YYYY-MM-DD` entry** in the established format:
@@ -82,10 +100,10 @@ After bumping, verify they all match `apps/*/package.json` before committing.
 
 6. **Show the user the proposed CHANGELOG entry** before writing it, unless previously told to
    proceed autonomously.
-7. **Apply the edits in parallel:** update `CHANGELOG.md`; bump `"version"` in every shippable
-   `apps/*/package.json`.
+7. **Apply the edits:** run `pnpm version:bump <tier|X.Y.Z>` (bumps ALL version files); then write the
+   `CHANGELOG.md` entry.
 8. **Commit and push:**
-   - `git add CHANGELOG.md` + every bumped `apps/*/package.json` (plus release files).
+   - `git add CHANGELOG.md` + all the bumped version files (`git add apps CHANGELOG.md` covers the app set).
    - Commit subject: `<type>: vX.Y.Z — <short narrative>` — `feat` (minor), `fix` (patch),
      `chore`/`refactor`/`docs`/`revert` as appropriate. Lowercase after colon, imperative,
      ≤72 chars, em-dash between version and narrative.
@@ -102,7 +120,13 @@ autonomously per task; show the CHANGELOG entry only if non-trivial or risky.
 ## Do not
 
 - Do NOT use `git commit --amend` to fold a bump into a prior commit unless asked.
-- Do NOT skip any shippable app `package.json`.
+- Do NOT hand-edit the version files when `pnpm version:bump` can do it. If you ever MUST edit
+  `apps/tv-tauri/src-tauri/Cargo.lock` by hand, **NEVER global-sed the version string** — a
+  `sed 's/0.13.1/0.13.2/g'` also rewrites any dependency crate pinned to that version (it bumped the `phf*`
+  crates to a nonexistent version and broke `cargo` + `pnpm dev`, v0.13.2). Change ONLY the `airwave`
+  package's `version` line (the one right after `name = "airwave"`). The script does exactly this, safely.
 - Do NOT use `--no-verify` to skip pre-commit hooks. Fix the underlying issue instead.
 - Do NOT push to `main` with `--force` under any circumstance.
 - Do NOT propose a fourth version segment.
+- Do NOT `git tag` on your own initiative — tags are James's explicit call every time (a `v*` tag triggers the
+  GHCR image build + self-host rollout).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Airwave are documented here.
 
+## [0.13.6] - 2026-09-05
+
+tv-native — a client-side freeze detector so a mid-program player freeze is finally visible (GitHub #31).
+
+### Added
+- **Freeze detector in the channel player** (`apps/tv-native/src/features/watch/use-tv-player.ts`). Playback
+  telemetry was a one-shot watchdog ~6s after each load, so a freeze *after* playback started recorded
+  nothing. The player's tick now watches liveness: once a program is playing (baseline anchored, not paused,
+  not buffering), if no mpv progress event arrives for 12s the native player has frozen (e.g. the tvOS mpv
+  deadlock, #30) and one `PlaybackLog` row is posted with outcome `stalled` and the freeze detail. The JS
+  thread and networking keep running during a native main-thread wedge (the heartbeat kept flowing in the #30
+  crash), so this is the only layer that can see such a freeze. Re-arms once progress resumes.
+
 ## [0.13.5] - 2026-09-05
 
 Repo tooling — a one-command, footgun-proof version bumper.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Airwave are documented here.
 
+## [0.13.5] - 2026-09-05
+
+Repo tooling — a one-command, footgun-proof version bumper.
+
+### Added
+- **`pnpm version:bump <patch|minor|major|X.Y.Z> [--dry-run]`** (`scripts/bump-version.ts`) sets every
+  Airwave version file in lockstep — all `apps/*/package.json` (discovered, not hardcoded), the webOS
+  `appinfo.json`, the Expo `app.json`, the Tauri `tauri.conf.json` / `Cargo.toml` / `Cargo.lock`, and the
+  Roku `manifest`. Every edit is **targeted** (a JSON `version` key, the manifest's three version lines, or
+  the single `airwave` package line in the Cargo files found via its `name = "airwave"` anchor), so a
+  dependency crate can never be bumped by accident. Refuses to run if the files are out of sync (surfaces the
+  mismatch instead of normalizing), and `--dry-run` previews without writing. Edits version files only — the
+  CHANGELOG entry + commit + push stay with the `/version-bump` flow.
+
 ## [0.13.4] - 2026-09-05
 
 tv-native (iOS / Apple TV) — fix a main-thread ⇄ mpv deadlock freeze (GitHub #30) and enable the player's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to Airwave are documented here.
 
+## [0.13.4] - 2026-09-05
+
+tv-native (iOS / Apple TV) — fix a main-thread ⇄ mpv deadlock freeze (GitHub #30) and enable the player's
+own logging (GitHub #31), by completing the port to plezy's async libmpv client API.
+
+### Fixed
+- **Apple TV / iPad no longer freeze on a main-thread ⇄ mpv deadlock (GitHub #30).** The Apple mpv core
+  (`packages/mpv-player/ios/MpvCore.swift`) called libmpv **synchronously on the calling thread**, and the
+  Expo view prop setters run on the **main thread**. On tvOS the `avfoundation` video output must
+  `dispatch_sync` to the main queue to touch its display layer; when that coincided with a main-thread mpv
+  call, the two deadlocked — a multi-minute freeze that tvOS killed with `0x8BADF00D`. Both Apple cores now
+  use libmpv's **async client API** (`mpv_command_async` / `mpv_set_property_async` with a request-id → reply
+  table); those submit and return immediately, never blocking the caller, so the deadlock is structurally
+  impossible. This completes the port from plezy's `MpvPlayerCoreBase` — we had ported the structure but kept
+  synchronous calls since v0.7.19. `MpvAudioCore` gets the same treatment for parity.
+
+### Added
+- **libmpv logging (GitHub #31).** Both Apple cores now request mpv log messages (verbose in debug,
+  warnings+ on a store build) and emit them via `os_log`, so a shipped app's player log is visible in
+  Console.app off a retail device — previously release builds had effectively no player logging. Remaining
+  `print()` calls replaced with `os_log`.
+
+### Changed
+- `avfoundation-composite-osd=no` on the Apple mpv output. Subtitles are selected/burned server-side (Plex),
+  so mpv's per-frame OSD compositing is not our render path; disabling it reduces video-output ↔ main-thread
+  coupling (matches plezy + streamyfin).
+
+### Verification
+- Native change — requires a fresh iOS/tvOS build; verify on device (Apple TV + iPad) before release.
+  On-device matrix + the #30 repro (HEVC copy + E-AC3→mp3 HLS, long session with transitions) in
+  `.plans/mpv-async-refactor.md`.
+
 ## [0.13.3] - 2026-09-04
 
 Promo — the Airwave sizzle reel, rebuilt in Remotion.

--- a/apps/desktop-setup/package.json
+++ b/apps/desktop-setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airwave/desktop-setup",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "private": true,
   "type": "module",
   "description": "Airwave Desktop first-run onboarding / settings UI — a small Vite + React app built with @airwave/ui (shadcn + oklch theme), rendered in the desktop app's native webview and driven by the supervisor's /config, /save, /status endpoints.",

--- a/apps/desktop-setup/package.json
+++ b/apps/desktop-setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airwave/desktop-setup",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "private": true,
   "type": "module",
   "description": "Airwave Desktop first-run onboarding / settings UI — a small Vite + React app built with @airwave/ui (shadcn + oklch theme), rendered in the desktop app's native webview and driven by the supervisor's /config, /save, /status endpoints.",

--- a/apps/desktop-setup/package.json
+++ b/apps/desktop-setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airwave/desktop-setup",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "private": true,
   "type": "module",
   "description": "Airwave Desktop first-run onboarding / settings UI — a small Vite + React app built with @airwave/ui (shadcn + oklch theme), rendered in the desktop app's native webview and driven by the supervisor's /config, /save, /status endpoints.",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "private": true,
   "type": "module",
   "description": "Airwave Desktop — an Electrobun tray-only supervisor that runs embedded Postgres + the Airwave server + admin + tv-web on local ports, next to Plex. The browser is the UI. See .plans/desktop-server.md.",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "private": true,
   "type": "module",
   "description": "Airwave Desktop — an Electrobun tray-only supervisor that runs embedded Postgres + the Airwave server + admin + tv-web on local ports, next to Plex. The browser is the UI. See .plans/desktop-server.md.",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "private": true,
   "type": "module",
   "description": "Airwave Desktop — an Electrobun tray-only supervisor that runs embedded Postgres + the Airwave server + admin + tv-web on local ports, next to Plex. The browser is the UI. See .plans/desktop-server.md.",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "site",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "site",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "site",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/tv-native/app.json
+++ b/apps/tv-native/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Airwave",
     "slug": "airwave",
-    "version": "0.13.3",
+    "version": "0.13.4",
     "scheme": "airwave",
     "orientation": "landscape",
     "userInterfaceStyle": "dark",

--- a/apps/tv-native/app.json
+++ b/apps/tv-native/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Airwave",
     "slug": "airwave",
-    "version": "0.13.4",
+    "version": "0.13.5",
     "scheme": "airwave",
     "orientation": "landscape",
     "userInterfaceStyle": "dark",

--- a/apps/tv-native/app.json
+++ b/apps/tv-native/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Airwave",
     "slug": "airwave",
-    "version": "0.13.5",
+    "version": "0.13.6",
     "scheme": "airwave",
     "orientation": "landscape",
     "userInterfaceStyle": "dark",

--- a/apps/tv-native/package.json
+++ b/apps/tv-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-native",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {

--- a/apps/tv-native/package.json
+++ b/apps/tv-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-native",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {

--- a/apps/tv-native/package.json
+++ b/apps/tv-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-native",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {

--- a/apps/tv-native/src/features/watch/use-tv-player.ts
+++ b/apps/tv-native/src/features/watch/use-tv-player.ts
@@ -98,6 +98,10 @@ const LOOKAHEAD_S = 6 * 60;
 // reloads (reset on any real progress) so a permanently-dead stream can't loop.
 const RESUME_STALL_MS = 5000;
 const RESUME_MAX_RETRIES = 2;
+// Freeze detector (GitHub #31): once a program is playing, if NO progress event arrives for this long while
+// we're meant to be playing (not paused/buffering), the native player has frozen mid-stream (e.g. the tvOS
+// mpv main-thread deadlock) — post one PlaybackLog so an otherwise-invisible freeze is recorded.
+const FREEZE_MS = 12000;
 
 const titleOf = (g?: GuideMeta | null) => (!g ? "" : g.showTitle ? `${g.showTitle} — ${g.title}` : g.title);
 
@@ -153,6 +157,7 @@ export function useTvPlayer(channelId: string | null, options: PlayerOptions = {
   // has loaded, so a stale onProgress from the outgoing stream can't anchor the new program's baseline.
   const bufferingRef = useRef(false); // latest onBuffering state — for the watchdog's stuck-diagnosis
   const loggedRef = useRef(false); // already logged this load (onLoad/onError)? the watchdog skips if so
+  const frozeLoggedRef = useRef(false); // #31: already posted a freeze row for the CURRENT stall episode? (re-arms on progress)
   // Resume-stall watchdog state (see RESUME_STALL_MS): armed on unpause; the tick reloads if mpv's clock
   // hasn't produced a progress event within the window; capped by resumeAttemptsRef (reset on progress).
   const lastProgressAtRef = useRef(0); // Date.now() of the last onProgress — the liveness signal
@@ -173,7 +178,7 @@ export function useTvPlayer(channelId: string | null, options: PlayerOptions = {
 
   // PlaybackLog: one row per program load — the server's decision (mode/codecs/connection, captured in
   // goTo) + the real on-device outcome (libVLC first-play dims, or an error message).
-  const recordLog = useCallback((outcome?: "playing" | "not_decoding" | "error", errorDetail?: string | null) => {
+  const recordLog = useCallback((outcome?: "playing" | "not_decoding" | "error" | "stalled", errorDetail?: string | null) => {
     const ctx = logCtxRef.current;
     if (!ctx) return;
     loggedRef.current = true;
@@ -331,6 +336,7 @@ export function useTvPlayer(channelId: string | null, options: PlayerOptions = {
           baselineArmedRef.current = false;
           bufferingRef.current = false;
           loggedRef.current = false;
+          frozeLoggedRef.current = false; // #31: fresh load → re-arm the freeze detector
           console.log(`[mpv] LOAD mode=${info.mode} offset=${offset}s conn=${info.connection ?? "?"} ${info.container ?? "?"}/${info.videoCodec ?? "?"}/${info.audioCodec ?? "?"} ${info.url.slice(0, 90)}`);
           setStartTime(info.mode === "direct" ? offset : 0);
           setSource(info.url);
@@ -551,6 +557,24 @@ export function useTvPlayer(channelId: string | null, options: PlayerOptions = {
           stallTicksRef.current = 0;
           lastPosSampleRef.current = positionSecRef.current;
         }
+        // Freeze detector (GitHub #31). A native player can freeze mid-stream with NO event — onProgress just
+        // stops (e.g. the tvOS mpv main-thread deadlock, where the delegate's DispatchQueue.main.async never
+        // drains). The JS thread + this tick keep running, and networking still works during a native
+        // main-thread wedge (the heartbeat kept flowing in the #30 crash), so JS is the ONLY layer that can see
+        // and report it. If we're meant to be playing (baseline anchored, not paused, not buffering) but no
+        // progress event has arrived for FREEZE_MS, post ONE PlaybackLog. Re-arms once progress resumes.
+        if (cur.baselineReady && firstProgressRef.current && !pausedRef.current && !bufferingRef.current) {
+          const sinceProgress = Date.now() - lastProgressAtRef.current;
+          if (sinceProgress >= FREEZE_MS) {
+            if (!frozeLoggedRef.current) {
+              frozeLoggedRef.current = true;
+              console.log(`[mpv] FREEZE detected — no progress for ${Math.round(sinceProgress / 1000)}s`);
+              recordLog("stalled", `frozen: no progress for ${Math.round(sinceProgress / 1000)}s (pos=${positionSecRef.current.toFixed(1)}s buffering=${bufferingRef.current})`);
+            }
+          } else {
+            frozeLoggedRef.current = false;
+          }
+        }
       } else {
         if (!pausedRef.current) bumperEffRef.current += wallDt;
         effective = bumperEffRef.current;
@@ -601,7 +625,7 @@ export function useTvPlayer(channelId: string | null, options: PlayerOptions = {
       }));
     }, 500);
     return () => clearInterval(id);
-  }, [now, goTo, currentEffective, buildScrubber]);
+  }, [now, goTo, currentEffective, buildScrubber, recordLog]);
 
   // Heartbeat the watch session (~10s) for Now Watching + orphan-transcode reap; end it on unmount.
   useEffect(() => {

--- a/apps/tv-roku/manifest
+++ b/apps/tv-roku/manifest
@@ -3,7 +3,7 @@ title=Airwave
 # Version — kept in lockstep with the other apps/* (see /version-bump). Mirrors package.json 0.12.0.
 major_version=0
 minor_version=13
-build_version=4
+build_version=5
 
 # Icons = branded logo mark on the radial gradient (home-screen tile). Splash = a FLAT #060a14 fill (Roku
 # requires a splash image, but ours hands off seamlessly to the in-app animated LogoLockup, which fades the

--- a/apps/tv-roku/manifest
+++ b/apps/tv-roku/manifest
@@ -3,7 +3,7 @@ title=Airwave
 # Version — kept in lockstep with the other apps/* (see /version-bump). Mirrors package.json 0.12.0.
 major_version=0
 minor_version=13
-build_version=3
+build_version=4
 
 # Icons = branded logo mark on the radial gradient (home-screen tile). Splash = a FLAT #060a14 fill (Roku
 # requires a splash image, but ours hands off seamlessly to the in-app animated LogoLockup, which fades the

--- a/apps/tv-roku/manifest
+++ b/apps/tv-roku/manifest
@@ -3,7 +3,7 @@ title=Airwave
 # Version — kept in lockstep with the other apps/* (see /version-bump). Mirrors package.json 0.12.0.
 major_version=0
 minor_version=13
-build_version=5
+build_version=6
 
 # Icons = branded logo mark on the radial gradient (home-screen tile). Splash = a FLAT #060a14 fill (Roku
 # requires a splash image, but ours hands off seamlessly to the in-app animated LogoLockup, which fades the

--- a/apps/tv-roku/package.json
+++ b/apps/tv-roku/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-roku",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "private": true,
   "description": "Airwave Roku client (BrighterScript + SceneGraph). A direct port of tv-web/tv-native to Roku — strict visual + functional parity, its own separately-maintained codebase.",
   "scripts": {

--- a/apps/tv-roku/package.json
+++ b/apps/tv-roku/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-roku",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "private": true,
   "description": "Airwave Roku client (BrighterScript + SceneGraph). A direct port of tv-web/tv-native to Roku — strict visual + functional parity, its own separately-maintained codebase.",
   "scripts": {

--- a/apps/tv-roku/package.json
+++ b/apps/tv-roku/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-roku",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "private": true,
   "description": "Airwave Roku client (BrighterScript + SceneGraph). A direct port of tv-web/tv-native to Roku — strict visual + functional parity, its own separately-maintained codebase.",
   "scripts": {

--- a/apps/tv-tauri/package.json
+++ b/apps/tv-tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-tauri",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/tv-tauri/package.json
+++ b/apps/tv-tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-tauri",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/tv-tauri/package.json
+++ b/apps/tv-tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-tauri",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/tv-tauri/src-tauri/Cargo.lock
+++ b/apps/tv-tauri/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "airwave"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "futures",
  "if-addrs",

--- a/apps/tv-tauri/src-tauri/Cargo.lock
+++ b/apps/tv-tauri/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "airwave"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "futures",
  "if-addrs",

--- a/apps/tv-tauri/src-tauri/Cargo.lock
+++ b/apps/tv-tauri/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "airwave"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "futures",
  "if-addrs",

--- a/apps/tv-tauri/src-tauri/Cargo.toml
+++ b/apps/tv-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "airwave"
-version = "0.13.3"
+version = "0.13.4"
 description = "Airwave desktop client (Tauri + libmpv)"
 authors = ["Airwave"]
 license = ""

--- a/apps/tv-tauri/src-tauri/Cargo.toml
+++ b/apps/tv-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "airwave"
-version = "0.13.4"
+version = "0.13.5"
 description = "Airwave desktop client (Tauri + libmpv)"
 authors = ["Airwave"]
 license = ""

--- a/apps/tv-tauri/src-tauri/Cargo.toml
+++ b/apps/tv-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "airwave"
-version = "0.13.5"
+version = "0.13.6"
 description = "Airwave desktop client (Tauri + libmpv)"
 authors = ["Airwave"]
 license = ""

--- a/apps/tv-tauri/src-tauri/tauri.conf.json
+++ b/apps/tv-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Airwave Client",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "identifier": "com.airwave.tvdesktop",
   "build": {
     "frontendDist": "../dist",

--- a/apps/tv-tauri/src-tauri/tauri.conf.json
+++ b/apps/tv-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Airwave Client",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "identifier": "com.airwave.tvdesktop",
   "build": {
     "frontendDist": "../dist",

--- a/apps/tv-tauri/src-tauri/tauri.conf.json
+++ b/apps/tv-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Airwave Client",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "identifier": "com.airwave.tvdesktop",
   "build": {
     "frontendDist": "../dist",

--- a/apps/tv-web/package.json
+++ b/apps/tv-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-web",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/tv-web/package.json
+++ b/apps/tv-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-web",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/tv-web/package.json
+++ b/apps/tv-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-web",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/tv-web/public/appinfo.json
+++ b/apps/tv-web/public/appinfo.json
@@ -1,6 +1,6 @@
 {
   "id": "com.airwave.tv",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "vendor": "Airwave",
   "type": "web",
   "main": "index.html",

--- a/apps/tv-web/public/appinfo.json
+++ b/apps/tv-web/public/appinfo.json
@@ -1,6 +1,6 @@
 {
   "id": "com.airwave.tv",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "vendor": "Airwave",
   "type": "web",
   "main": "index.html",

--- a/apps/tv-web/public/appinfo.json
+++ b/apps/tv-web/public/appinfo.json
@@ -1,6 +1,6 @@
 {
   "id": "com.airwave.tv",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "vendor": "Airwave",
   "type": "web",
   "main": "index.html",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "turbo run dev --filter=!desktop --filter=!@airwave/desktop-setup",
     "dev:core": "turbo run dev -F server -F web -F tv-web",
     "dev:setup": "bun scripts/dev-setup.ts",
+    "version:bump": "bun scripts/bump-version.ts",
     "build": "turbo run build --filter=!tv-tauri",
     "check-types": "turbo run check-types",
     "dev:web": "turbo run dev -F web",

--- a/packages/mpv-player/ios/MpvAudioCore.swift
+++ b/packages/mpv-player/ios/MpvAudioCore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Libmpv
+import os
 
 /// A HEADLESS (no video surface) audio-only libmpv core — for the bumper music bed (§7.14 Phase B) and future
 /// audio-only "radio" channels. Ported from plezy's `MpvAudioPlayerCore`: create → set `vid=no` /
@@ -27,6 +28,14 @@ final class MpvAudioCore {
   private var currentVolume: Double = 1.0
   private var fadeTimer: DispatchSourceTimer?
 
+  private let log = Logger(subsystem: "com.airwave.tv", category: "mpv-audio")
+
+  // Async request table — same as MpvCore (see .plans/mpv-async-refactor.md). Keeps this headless core off the
+  // synchronous client API too, for parity and so it's safe to call from any thread.
+  private var pendingRequests: [UInt64: (Result<Void, Error>) -> Void] = [:]
+  private let pendingRequestsLock = NSLock()
+  private var nextRequestId: UInt64 = 1
+
   @discardableResult
   func setup() -> Bool {
     // SESSION-PASSIVE: this headless bumper-music core NEVER touches the shared AVAudioSession. The app
@@ -36,6 +45,13 @@ final class MpvAudioCore {
 
     mpv = mpv_create()
     guard let mpv else { return false }
+
+    // libmpv log → os_log (verbose debug / warnings on a store build). GitHub #31.
+    #if DEBUG
+      _ = mpv_request_log_messages(mpv, "v")
+    #else
+      _ = mpv_request_log_messages(mpv, "warn")
+    #endif
 
     // Audio-only, headless. No `wid`, no VO surface — the whole point.
     let opts: [String: String] = [
@@ -148,6 +164,7 @@ final class MpvAudioCore {
   func dispose() {
     isDisposing = true
     cancelFade()
+    cancelPendingRequests()
     let handle = mpv
     let ctx = wakeupContext
     mpv = nil
@@ -163,20 +180,68 @@ final class MpvAudioCore {
 
   // MARK: mpv primitives (trimmed copy of MpvCore's — kept local so the video core stays untouched)
 
+  // Async client API (see MpvCore / .plans/mpv-async-refactor.md) — non-blocking submits, replies drained in `handle`.
+
   private func command(_ args: [String]) {
-    guard let mpv else { return }
+    guard let mpv, !args.isEmpty else { return }
+    let requestId = registerRequest { _ in }
     var cargs: [UnsafeMutablePointer<CChar>?] = args.map { strdup($0) }
     cargs.append(nil)
     cargs.withUnsafeBufferPointer { buffer in
       var constPointers = buffer.map { $0.map { UnsafePointer($0) } }
-      _ = mpv_command(mpv, &constPointers)
+      let status = mpv_command_async(mpv, requestId, &constPointers)
+      completeRequestIfSubmissionFailed(requestId: requestId, status: status)
     }
     cargs.forEach { free($0) }
   }
 
   private func setProperty(_ name: String, _ value: String) {
     guard let mpv else { return }
-    _ = mpv_set_property_string(mpv, name, value)
+    let requestId = registerRequest { _ in }
+    let status = name.withCString { namePtr in
+      value.withCString { valuePtr in
+        var propertyValue: UnsafePointer<CChar>? = valuePtr
+        return mpv_set_property_async(mpv, requestId, namePtr, MPV_FORMAT_STRING, &propertyValue)
+      }
+    }
+    completeRequestIfSubmissionFailed(requestId: requestId, status: status)
+  }
+
+  // MARK: async request table
+
+  private func registerRequest(_ completion: @escaping (Result<Void, Error>) -> Void) -> UInt64 {
+    pendingRequestsLock.lock()
+    defer { pendingRequestsLock.unlock() }
+    let id = nextRequestId
+    nextRequestId += 1
+    pendingRequests[id] = completion
+    return id
+  }
+
+  private func takeRequest(_ id: UInt64) -> ((Result<Void, Error>) -> Void)? {
+    pendingRequestsLock.lock()
+    defer { pendingRequestsLock.unlock() }
+    return pendingRequests.removeValue(forKey: id)
+  }
+
+  private func completeRequestIfSubmissionFailed(requestId: UInt64, status: CInt) {
+    guard status < 0, let completion = takeRequest(requestId) else { return }
+    DispatchQueue.main.async { completion(.failure(NSError(domain: "mpv", code: Int(status)))) }
+  }
+
+  private func completeVoidRequest(requestId: UInt64, error status: CInt) {
+    if status < 0 { log.error("mpv async op failed: \(mpvSafeString(mpv_error_string(status)), privacy: .public)") }
+    guard let completion = takeRequest(requestId) else { return }
+    DispatchQueue.main.async { completion(status < 0 ? .failure(NSError(domain: "mpv", code: Int(status))) : .success(())) }
+  }
+
+  private func cancelPendingRequests() {
+    pendingRequestsLock.lock()
+    let pending = pendingRequests
+    pendingRequests.removeAll()
+    pendingRequestsLock.unlock()
+    let err = NSError(domain: "mpv", code: -1)
+    for (_, completion) in pending { DispatchQueue.main.async { completion(.failure(err)) } }
   }
 
   private func getDouble(_ name: String) -> Double {
@@ -228,6 +293,21 @@ final class MpvAudioCore {
                 prop.format == MPV_FORMAT_FLAG,
                 let f = prop.data?.assumingMemoryBound(to: Int32.self).pointee {
         DispatchQueue.main.async { self.onBuffering?(f != 0) }
+      }
+    case MPV_EVENT_COMMAND_REPLY, MPV_EVENT_SET_PROPERTY_REPLY:
+      completeVoidRequest(requestId: event.reply_userdata, error: event.error)
+    case MPV_EVENT_LOG_MESSAGE:
+      guard let p = event.data?.assumingMemoryBound(to: mpv_event_log_message.self) else { break }
+      let prefix = p.pointee.prefix.map { mpvSafeString($0) } ?? ""
+      let level = p.pointee.level.map { mpvSafeString($0) } ?? ""
+      let text = (p.pointee.text.map { mpvSafeString($0) } ?? "").trimmingCharacters(in: .newlines)
+      if text.isEmpty { break }
+      if level == "fatal" || level == "error" {
+        log.error("[\(prefix, privacy: .public)] \(text, privacy: .public)")
+      } else if level == "warn" {
+        log.notice("[\(prefix, privacy: .public)] \(text, privacy: .public)")
+      } else {
+        log.debug("[\(prefix, privacy: .public)] \(text, privacy: .public)")
       }
     default:
       break

--- a/packages/mpv-player/ios/MpvCore.swift
+++ b/packages/mpv-player/ios/MpvCore.swift
@@ -2,6 +2,17 @@ import AVFoundation
 import Foundation
 import Libmpv
 import QuartzCore
+import os
+
+/// Safely convert an mpv C string to a Swift String. mpv does NOT guarantee UTF-8 for log messages, error
+/// strings, or system-encoded paths — validate as UTF-8, else fall back to Latin-1 so we never crash on
+/// non-UTF-8 bytes. (Ported from plezy's `MpvPlayerCoreBase.safeString`.)
+func mpvSafeString(_ cstr: UnsafePointer<CChar>) -> String {
+  if let s = String(validatingUTF8: cstr) { return s }
+  let len = strlen(cstr)
+  let buf = UnsafeBufferPointer(start: UnsafeRawPointer(cstr).assumingMemoryBound(to: UInt8.self), count: len)
+  return String(buf.map { Character(Unicode.Scalar($0)) })
+}
 
 /// Events surfaced from the mpv render/event loop up to the Expo view.
 protocol MpvCoreDelegate: AnyObject {
@@ -35,6 +46,16 @@ final class MpvCore {
   private var currentVolume: Double = 100
   private var fadeTimer: DispatchSourceTimer?
 
+  private let log = Logger(subsystem: "com.airwave.tv", category: "mpv")
+
+  // Async request table (ported from plezy's MpvPlayerCoreBase): every mpv_command_async /
+  // mpv_set_property_async submits with a reply id, and the matching MPV_EVENT_*_REPLY drains its completion.
+  // The async client API returns IMMEDIATELY (never blocks the caller), so a libmpv call on the MAIN thread
+  // can no longer deadlock against the avfoundation VO's dispatch_sync(main). See .plans/mpv-async-refactor.md.
+  private var pendingRequests: [UInt64: (Result<Void, Error>) -> Void] = [:]
+  private let pendingRequestsLock = NSLock()
+  private var nextRequestId: UInt64 = 1
+
   // MARK: setup
 
   /// Create + initialize mpv, rendering into `layer` (its pointer is handed to mpv as `wid`, which the
@@ -50,6 +71,15 @@ final class MpvCore {
     mpv = mpv_create()
     guard let mpv else { return false }
 
+    // Enable libmpv's own log BEFORE initialize, so a stalled/failing pipeline is diagnosable — verbose in
+    // debug, warnings+ on a store build (which `print` never reached). Surfaced via os_log in `handleLogMessage`
+    // → visible in Console.app off a retail device. (plezy does this; we had dropped it. GitHub #31.)
+    #if DEBUG
+      checkError(mpv_request_log_messages(mpv, "v"))
+    #else
+      checkError(mpv_request_log_messages(mpv, "warn"))
+    #endif
+
     // Point the avfoundation VO at our layer.
     var wid = Int64(Int(bitPattern: Unmanaged.passUnretained(layer).toOpaque()))
     checkError(mpv_set_option(mpv, "wid", MPV_FORMAT_INT64, &wid))
@@ -57,6 +87,10 @@ final class MpvCore {
     // Defaults (overridable via `options`).
     var opts: [String: String] = [
       "vo": "avfoundation",
+      // Don't composite the OSD (subtitles) onto frames in the VO: our subtitles are burned/selected
+      // SERVER-SIDE (Plex PUT ?subtitleStreamID= + transcode), so mpv's OSD isn't our render path. Compositing
+      // does per-frame CoreImage work that widens the VO↔main coupling on tvOS. Matches plezy + streamyfin.
+      "avfoundation-composite-osd": "no",
       "hwdec": "videotoolbox",
       "hwdec-codecs": "all",
       "target-colorspace-hint": "auto",
@@ -222,6 +256,7 @@ final class MpvCore {
   func dispose() {
     isDisposing = true
     cancelFade()
+    cancelPendingRequests()
     let handle = mpv
     let ctx = wakeupContext
     mpv = nil
@@ -256,27 +291,94 @@ final class MpvCore {
       try session.setCategory(.playback, mode: .moviePlayback, policy: .longFormAudio, options: [])
       try session.setActive(true)
     } catch {
-      print("[MpvCore] audio session config failed: \(error)")
+      log.error("audio session config failed: \(error.localizedDescription, privacy: .public)")
     }
   }
 
   // MARK: mpv primitives
 
-  private func command(_ args: [String]) {
-    guard let mpv else { return }
+  // All mutations go through the ASYNC client API (mpv_command_async / mpv_set_property_async). These submit
+  // to mpv's internal core and return immediately — they NEVER block the caller — so it's safe to call them
+  // from ANY thread, including the main thread (Expo `Prop` setters run there). mpv executes submissions in
+  // ORDER on its own core, so the load-then-reset sequence in `load()` still applies in order. Completions are
+  // fired when the matching MPV_EVENT_*_REPLY arrives (see `handle`); our callers are fire-and-forget, but the
+  // reply path still surfaces any mpv error to os_log. (Ported from plezy's MpvPlayerCoreBase.)
+
+  private func command(_ args: [String]) { commandAsync(args) { _ in } }
+
+  private func commandAsync(_ args: [String], completion: @escaping (Result<Void, Error>) -> Void) {
+    guard let mpv, !args.isEmpty else { completion(.success(())); return }
+    let requestId = registerRequest(completion)
     var cargs: [UnsafeMutablePointer<CChar>?] = args.map { strdup($0) }
     cargs.append(nil)
     cargs.withUnsafeBufferPointer { buffer in
-      // mpv_command wants `const char **` — rebind the strdup'd mutable pointers to const (plezy's pattern).
+      // mpv_command_async wants `const char **` — rebind the strdup'd mutable pointers to const (plezy's pattern).
       var constPointers = buffer.map { $0.map { UnsafePointer($0) } }
-      _ = mpv_command(mpv, &constPointers)
+      let status = mpv_command_async(mpv, requestId, &constPointers)
+      completeRequestIfSubmissionFailed(requestId: requestId, status: status)
     }
     cargs.forEach { free($0) }
   }
 
-  private func setProperty(_ name: String, _ value: String) {
-    guard let mpv else { return }
-    _ = mpv_set_property_string(mpv, name, value)
+  private func setProperty(_ name: String, _ value: String) { setPropertyAsync(name, value) { _ in } }
+
+  private func setPropertyAsync(_ name: String, _ value: String, completion: @escaping (Result<Void, Error>) -> Void) {
+    guard let mpv else { completion(.success(())); return }
+    let requestId = registerRequest(completion)
+    let status = name.withCString { namePtr in
+      value.withCString { valuePtr in
+        var propertyValue: UnsafePointer<CChar>? = valuePtr
+        return mpv_set_property_async(mpv, requestId, namePtr, MPV_FORMAT_STRING, &propertyValue)
+      }
+    }
+    completeRequestIfSubmissionFailed(requestId: requestId, status: status)
+  }
+
+  // MARK: async request table
+
+  private func registerRequest(_ completion: @escaping (Result<Void, Error>) -> Void) -> UInt64 {
+    pendingRequestsLock.lock()
+    defer { pendingRequestsLock.unlock() }
+    let id = nextRequestId
+    nextRequestId += 1
+    pendingRequests[id] = completion
+    return id
+  }
+
+  private func takeRequest(_ id: UInt64) -> ((Result<Void, Error>) -> Void)? {
+    pendingRequestsLock.lock()
+    defer { pendingRequestsLock.unlock() }
+    return pendingRequests.removeValue(forKey: id)
+  }
+
+  private func mpvError(_ status: CInt) -> NSError {
+    NSError(domain: "mpv", code: Int(status), userInfo: [NSLocalizedDescriptionKey: mpvSafeString(mpv_error_string(status))])
+  }
+
+  /// The async submit itself failed (rare — bad args / no core). Fire the completion now; no reply will come.
+  private func completeRequestIfSubmissionFailed(requestId: UInt64, status: CInt) {
+    guard status < 0, let completion = takeRequest(requestId) else { return }
+    let err = mpvError(status)
+    DispatchQueue.main.async { completion(.failure(err)) }
+  }
+
+  /// Drain a command/set-property reply: log any mpv error (observability), then fire the completion on main.
+  private func completeVoidRequest(requestId: UInt64, error status: CInt) {
+    if status < 0 {
+      log.error("mpv async op failed: \(mpvSafeString(mpv_error_string(status)), privacy: .public)")
+    }
+    guard let completion = takeRequest(requestId) else { return }
+    DispatchQueue.main.async { completion(status < 0 ? .failure(self.mpvError(status)) : .success(())) }
+  }
+
+  /// Fail every outstanding completion (called on dispose) so nothing leaks or hangs.
+  private func cancelPendingRequests() {
+    pendingRequestsLock.lock()
+    let pending = pendingRequests
+    pendingRequests.removeAll()
+    pendingRequestsLock.unlock()
+    let err = NSError(domain: "mpv", code: -1, userInfo: [NSLocalizedDescriptionKey: "Player disposed"])
+    for (_, completion) in pending { DispatchQueue.main.async { completion(.failure(err)) } }
   }
 
   // MARK: event loop
@@ -334,8 +436,31 @@ final class MpvCore {
     case MPV_EVENT_PROPERTY_CHANGE:
       guard let data = event.data else { break }
       handleProperty(data.assumingMemoryBound(to: mpv_event_property.self).pointee)
+    case MPV_EVENT_COMMAND_REPLY, MPV_EVENT_SET_PROPERTY_REPLY:
+      // Async submit finished — fire its completion (and log any mpv error).
+      completeVoidRequest(requestId: event.reply_userdata, error: event.error)
+    case MPV_EVENT_LOG_MESSAGE:
+      handleLogMessage(event)
     default:
       break
+    }
+  }
+
+  /// mpv's own log line (level requested in `setup`) → os_log, so a store build's Console.app can answer
+  /// "why did the video stop". Runs on the mpv queue (from the event loop). GitHub #31.
+  private func handleLogMessage(_ event: mpv_event) {
+    guard let p = event.data?.assumingMemoryBound(to: mpv_event_log_message.self) else { return }
+    let prefix = p.pointee.prefix.map { mpvSafeString($0) } ?? ""
+    let level = p.pointee.level.map { mpvSafeString($0) } ?? ""
+    let text = (p.pointee.text.map { mpvSafeString($0) } ?? "").trimmingCharacters(in: .newlines)
+    if text.isEmpty { return }
+    switch level {
+    case "fatal", "error":
+      log.error("[\(prefix, privacy: .public)] \(text, privacy: .public)")
+    case "warn":
+      log.notice("[\(prefix, privacy: .public)] \(text, privacy: .public)")
+    default:
+      log.debug("[\(prefix, privacy: .public)] \(text, privacy: .public)")
     }
   }
 
@@ -405,6 +530,6 @@ final class MpvCore {
   }
 
   private func checkError(_ status: CInt) {
-    if status < 0 { print("[MpvCore] error: \(String(cString: mpv_error_string(status)))") }
+    if status < 0 { log.error("error: \(mpvSafeString(mpv_error_string(status)), privacy: .public)") }
   }
 }

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -1,0 +1,203 @@
+#!/usr/bin/env bun
+/**
+ * bump-version — set every Airwave version file in lockstep, safely.
+ *
+ *   pnpm version:bump <patch|minor|major|X.Y.Z> [--dry-run]
+ *
+ * Writes ONLY version files (never the changelog, never git). The `/version-bump` flow still owns the
+ * CHANGELOG entry + commit + push — this just does the mechanical, error-prone file edits so nobody has to
+ * hand-sed a dozen files (and so we can never again global-sed Cargo.lock and bump a dependency crate by
+ * accident — see the phf incident, .plans/feedback-versioning).
+ *
+ * Every edit is TARGETED: a JSON `"version"` key, the roku manifest's three version lines, or the single
+ * `airwave` package's `version` line in Cargo.toml / Cargo.lock (found via its `name = "airwave"` anchor,
+ * never a blind find-replace). Refuses to run if the version files are out of sync (surfaces the mismatch
+ * rather than silently normalizing). Three segments only — never a fourth.
+ */
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = process.cwd();
+const DRY = process.argv.includes("--dry-run") || process.argv.includes("--check");
+const ARG = process.argv.slice(2).find((a) => !a.startsWith("-"));
+
+// ── ANSI (no dep) ────────────────────────────────────────────────────────────
+const c = {
+  dim: (s: string) => `\x1b[2m${s}\x1b[0m`,
+  bold: (s: string) => `\x1b[1m${s}\x1b[0m`,
+  green: (s: string) => `\x1b[32m${s}\x1b[0m`,
+  red: (s: string) => `\x1b[31m${s}\x1b[0m`,
+  cyan: (s: string) => `\x1b[36m${s}\x1b[0m`,
+  yellow: (s: string) => `\x1b[33m${s}\x1b[0m`,
+};
+const die = (msg: string): never => {
+  console.error(`\n${c.red("✖")} ${msg}\n`);
+  process.exit(1);
+};
+
+// ── target discovery ─────────────────────────────────────────────────────────
+type Kind = "jsonVersion" | "rokuManifest" | "cargoPackage" | "cargoLockPackage";
+type Target = { path: string; kind: Kind };
+
+function appPackageJsons(): string[] {
+  // Discover apps/* (don't hardcode — apps are added over time, per /version-bump). A shippable app is a
+  // direct child of apps/ with a package.json.
+  const appsDir = join(ROOT, "apps");
+  const out: string[] = [];
+  for (const name of readdirSync(appsDir)) {
+    const pkg = join(appsDir, name, "package.json");
+    try {
+      if (statSync(pkg).isFile()) out.push(pkg);
+    } catch {
+      /* no package.json here */
+    }
+  }
+  return out.sort();
+}
+
+const TARGETS: Target[] = [
+  ...appPackageJsons().map((path): Target => ({ path, kind: "jsonVersion" })),
+  { path: join(ROOT, "apps/tv-web/public/appinfo.json"), kind: "jsonVersion" }, // webOS manifest
+  { path: join(ROOT, "apps/tv-native/app.json"), kind: "jsonVersion" }, // Expo
+  { path: join(ROOT, "apps/tv-tauri/src-tauri/tauri.conf.json"), kind: "jsonVersion" },
+  { path: join(ROOT, "apps/tv-tauri/src-tauri/Cargo.toml"), kind: "cargoPackage" },
+  { path: join(ROOT, "apps/tv-tauri/src-tauri/Cargo.lock"), kind: "cargoLockPackage" },
+  { path: join(ROOT, "apps/tv-roku/manifest"), kind: "rokuManifest" },
+];
+
+// ── per-kind read/write (all targeted; return [currentVersion, updatedText] ) ──
+const SEMVER = /^(\d+)\.(\d+)\.(\d+)$/;
+
+/** First `"version": "X.Y.Z"` value in a JSON file. */
+function jsonRead(text: string): string | null {
+  return text.match(/"version"\s*:\s*"(\d+\.\d+\.\d+)"/)?.[1] ?? null;
+}
+function jsonWrite(text: string, next: string): string {
+  return text.replace(/("version"\s*:\s*")(\d+\.\d+\.\d+)(")/, `$1${next}$3`); // first occurrence only
+}
+
+/** Roku manifest: major_version / minor_version / build_version → "maj.min.build". */
+function rokuRead(text: string): string | null {
+  const maj = text.match(/^major_version=(\d+)$/m)?.[1];
+  const min = text.match(/^minor_version=(\d+)$/m)?.[1];
+  const bld = text.match(/^build_version=(\d+)$/m)?.[1];
+  return maj && min && bld ? `${maj}.${min}.${bld}` : null;
+}
+function rokuWrite(text: string, next: string): string {
+  const [maj, min, bld] = next.split(".");
+  return text
+    .replace(/^major_version=\d+$/m, `major_version=${maj}`)
+    .replace(/^minor_version=\d+$/m, `minor_version=${min}`)
+    .replace(/^build_version=\d+$/m, `build_version=${bld}`);
+}
+
+/**
+ * The `airwave` package's `version` line in Cargo.toml / Cargo.lock — found via its `name = "airwave"`
+ * anchor, so dependency crates (phf, if-addrs, reqwest, …) are NEVER touched. This is the whole reason the
+ * script exists.
+ */
+function cargoRead(text: string): string | null {
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === 'name = "airwave"') {
+      for (let j = i + 1; j < Math.min(i + 6, lines.length); j++) {
+        const m = lines[j].match(/^version = "(\d+\.\d+\.\d+)"$/);
+        if (m) return m[1];
+      }
+    }
+  }
+  return null;
+}
+function cargoWrite(text: string, next: string): string {
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === 'name = "airwave"') {
+      for (let j = i + 1; j < Math.min(i + 6, lines.length); j++) {
+        if (/^version = "\d+\.\d+\.\d+"$/.test(lines[j])) {
+          lines[j] = `version = "${next}"`;
+          return lines.join("\n");
+        }
+      }
+    }
+  }
+  return text;
+}
+
+function readVersion(t: Target, text: string): string | null {
+  switch (t.kind) {
+    case "jsonVersion":
+      return jsonRead(text);
+    case "rokuManifest":
+      return rokuRead(text);
+    case "cargoPackage":
+    case "cargoLockPackage":
+      return cargoRead(text);
+  }
+}
+function writeVersion(t: Target, text: string, next: string): string {
+  switch (t.kind) {
+    case "jsonVersion":
+      return jsonWrite(text, next);
+    case "rokuManifest":
+      return rokuWrite(text, next);
+    case "cargoPackage":
+    case "cargoLockPackage":
+      return cargoWrite(text, next);
+  }
+}
+
+const rel = (p: string) => p.slice(ROOT.length + 1).replace(/\\/g, "/");
+
+// ── load + validate current state ────────────────────────────────────────────
+type Loaded = { t: Target; text: string; current: string };
+const loaded: Loaded[] = [];
+const missing: string[] = [];
+for (const t of TARGETS) {
+  let text: string;
+  try {
+    text = readFileSync(t.path, "utf8");
+  } catch {
+    missing.push(rel(t.path));
+    continue;
+  }
+  const current = readVersion(t, text);
+  if (!current) die(`Could not find a version in ${rel(t.path)} — the file format may have changed. Update scripts/bump-version.ts.`);
+  loaded.push({ t, text, current });
+}
+if (missing.length) die(`Version file(s) not found:\n  ${missing.join("\n  ")}\nUpdate scripts/bump-version.ts if a file moved.`);
+
+// Canonical = apps/server/package.json; everything must match it.
+const canonical = loaded.find((l) => rel(l.t.path) === "apps/server/package.json") ?? loaded[0];
+const current = canonical.current;
+const mismatched = loaded.filter((l) => l.current !== current);
+if (mismatched.length) {
+  console.error(`\n${c.red("✖ Version files are OUT OF SYNC")} (canonical ${c.bold(current)} from ${rel(canonical.t.path)}):`);
+  for (const l of mismatched) console.error(`  ${c.yellow(l.current.padEnd(10))} ${rel(l.t.path)}`);
+  console.error(`\nResolve the mismatch by hand first (it may be intentional or a botched prior bump).\n`);
+  process.exit(1);
+}
+
+// ── compute next version ─────────────────────────────────────────────────────
+if (!ARG) die("Usage: pnpm version:bump <patch|minor|major|X.Y.Z> [--dry-run]");
+const [maj, min, pat] = current.split(".").map(Number);
+let next: string;
+if (ARG === "patch") next = `${maj}.${min}.${pat + 1}`;
+else if (ARG === "minor") next = `${maj}.${min + 1}.0`;
+else if (ARG === "major") next = `${maj + 1}.0.0`;
+else if (SEMVER.test(ARG)) next = ARG;
+else die(`Invalid argument "${ARG}". Use patch | minor | major | X.Y.Z (three segments, never four).`);
+
+if (next! === current) die(`New version equals current (${current}); nothing to do.`);
+
+// ── apply ────────────────────────────────────────────────────────────────────
+console.log(`\n${c.bold("Airwave version bump")}  ${c.dim(current)} ${c.dim("→")} ${c.cyan(c.bold(next!))}${DRY ? c.yellow("   (dry run — no files written)") : ""}\n`);
+for (const l of loaded) {
+  const updated = writeVersion(l.t, l.text, next!);
+  if (updated === l.text) die(`No change applied to ${rel(l.t.path)} — targeted replace matched nothing. Aborting so the set stays consistent.`);
+  if (!DRY) writeFileSync(l.t.path, updated);
+  console.log(`  ${c.green("✓")} ${rel(l.t.path)}`);
+}
+console.log(
+  `\n${c.green("Done.")} ${loaded.length} files ${DRY ? "would be" : ""} set to ${c.bold(next!)}.` +
+    `\n${c.dim("Next: write the CHANGELOG entry, then commit + push (see /version-bump).")}\n`,
+);

--- a/tools/promo/vo-script.md
+++ b/tools/promo/vo-script.md
@@ -1,0 +1,32 @@
+# Airwave promo — voiceover script
+
+One continuous narration, one line per section, in the warm second-person voice of the intro. Lengths are
+tuned to each scene's current runtime (scene timings can flex to the real audio when we wire `<Audio>` in).
+Suggested audio files: drop each as `assets/vo/<file>` and we'll mount one per `<Sequence>`.
+
+| # | Scene | Scene dur | File | Line |
+|---|-------|-----------|------|------|
+| 1 | Intro | 5.0s | `01-intro` | *Introducing Airwave... turn your Plex library into your own always-on live TV.* **(done)** |
+| 2 | Guide | 5.2s | `02-guide` | It starts with a real channel guide — every channel on its own always-on schedule. |
+| 3 | Live | 5.0s | `03-live` | Tune in and join whatever's on right now, mid-program — just like live TV. |
+| 4 | DVR | 4.6s | `04-dvr` | There's a DVR, too — rewind, restart, or jump straight back to live. |
+| 5 | Surf | 4.8s | `05-surf` | Flip up and down the dial and surf your channels, like an old cable box. |
+| 6 | Bumpers | 5.0s | `06-bumpers` | Between shows, clean "Up Next" bumpers — with an optional music bed. |
+| 7 | Build | 5.0s | `07-build` | Building a channel is easy — just point a filter at your library and go. |
+| 8 | Organize | 5.0s | `08-organize` | Group your channels into packages, and share them with each user, Plex-style. |
+| 9 | Everywhere | 3.6s | `09-everywhere` | And it plays on every screen you own. |
+| 10 | Optional AI | 5.0s | `10-ai` | Bring your own AI key and let it draft entire lineups — totally optional. |
+| 11 | Self-host | 5.4s | `11-selfhost` | And you host it all yourself — up and running in a single command. |
+| 12 | Outro | 8.0s | `12-outro` | Your media, your channels — on every screen, and on any server you run. That's Airwave. Get it at getairwave.tv. |
+
+## Read direction
+- Warm, confident, unhurried; a light lift on the accent words (guide, live, DVR, surf, bumpers, build, share,
+  every screen, AI, host it all).
+- Small breath between sections; the reel already fades/blur-swaps between scenes, so pauses land naturally.
+- Total spoken ≈ 55-60s, matching the ~61.6s reel with a little room to breathe.
+
+## Wiring (next step, after audio exists)
+- Put clips in `assets/vo/` (served via `staticFile("vo/…")`).
+- Mount each in its scene's `<Sequence>` as `<Audio src={staticFile(...)} />`; flex each scene's `dur` in
+  `src/theme.ts` to its clip length.
+- Add a music bed as a top-level `<Audio loop volume={…}>`, ducked under the VO (Remotion volume automation).


### PR DESCRIPTION
## Summary

Completes the port from plezy's `MpvPlayerCoreBase` to fix the tvOS main-thread ⇄ mpv `vo`-thread deadlock (**#30**) and add the player observability that made it invisible (**#31**).

Our Apple mpv core called libmpv **synchronously on the calling thread**, and Expo view prop setters run on the **main thread**. On tvOS the `avfoundation` VO must `dispatch_sync` to the main queue to touch its `AVSampleBufferDisplayLayer`; when that coincided with a main-thread mpv call, the two deadlocked — a multi-minute freeze that tvOS killed with `0x8BADF00D`. This was a port shortcut present since v0.7.19 (we kept plezy's structure but dropped its async client API), not a deliberate choice.

## What changed

- **`MpvCore.swift` + `MpvAudioCore.swift` → libmpv async client API** (`mpv_command_async` / `mpv_set_property_async` + a request-id → reply table drained by `MPV_EVENT_*_REPLY`). Submits return immediately and never block the caller, so the deadlock is structurally impossible. mpv preserves submission order, so the load-then-reset sequence is unchanged. (**#30**)
- **libmpv logging → `os_log`** (`mpv_request_log_messages` + `MPV_EVENT_LOG_MESSAGE`, verbose in debug / warnings on store builds), visible in Console.app off a retail device. Remaining `print()`s replaced. (**#31**)
- **`avfoundation-composite-osd=no`** — subtitles are selected/burned server-side (Plex), so mpv's per-frame OSD compositing isn't our render path; disabling it reduces VO ↔ main coupling (matches plezy + streamyfin).
- **Client freeze detector** in `use-tv-player.ts` — once a program is playing, if no progress event arrives for 12s the native player has frozen; posts one `PlaybackLog` with outcome `stalled`. The JS thread + networking keep running during a native wedge (the heartbeat kept flowing in the #30 crash), so this is the only layer that can see it. (**#31**)
- **Also folded in:** `pnpm version:bump` (`scripts/bump-version.ts`) — lockstep, targeted version bumps across all 15 version files (no more hand-sed / Cargo.lock footgun) — and the `/version-bump` skill now points at it. Plus the promo `vo-script.md`.

The hybrid single-engine model, tvOS HDR display-criteria, 5.1/AVAudioSession, DVR clock, and load coalescing are untouched.

## Verification

Apple TV dev build (`development-tvos`, via Xcode): direct-play at offset, DVR seeks, program rollovers, the full 49-clip caps diagnostic, 4K HEVC/TrueHD at offset, and subtitles — all clean, **no regressions, no freeze**. iPad is shared code.

**Caveat:** the #30 deadlock only manifests on the HEVC-copy + E-AC3→mp3 **HLS transcode** path, which can't be reproduced on a direct-play LAN setup — real-world confirmation comes from the reporter once this reaches a store/TestFlight build. The fix is structural, so shipping to get field confirmation is the plan.

Design + on-device matrix: `.plans/mpv-async-refactor.md`.

Fixes #30
Fixes #31