### PR TITLE
Android HDR: pick the mpv VO up front + fix the letterbox sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to Airwave are documented here.
 
+## [0.13.21] - 2026-09-10
+
+Android TV — pick the mpv video output UP FRONT from the program's known dynamic range (HDR fix).
+
+### Changed
+- **HDR video output is now chosen at the load boundary, not on the first decoded frame.** Each program's
+  dynamic range is known in advance (the server's `guide.hdr`, delivered on the media resolve response as
+  `hdr`), so the Android mpv core opens HDR content directly on `vo=mediacodec_embed` (+ zero-copy
+  `hwdec=mediacodec`, real HDR10/HLG/Dolby Vision passthrough) and SDR on `gpu-next` (`gpu` on the Shield) —
+  set BEFORE that program's `loadfile`. This replaces the old detect-on-first-frame + `loadfile replace`
+  re-open, which caused two device-confirmed regressions: seeking back across a program boundary restarted
+  the program from 0, and the mid-stream surface switch produced reconfigure flicker and an HDR↔Dolby-Vision
+  badge flip. There is no mid-stream switch anymore, so neither can happen.
+- **Bumpers and audio-only loads leave the video output untouched** (they carry no dynamic-range flag), so an
+  `HDR program → bumper → HDR program` run stays on the HDR path end-to-end with no pointless switching —
+  matching the iOS behavior.
+
+### Added
+- A declarative `dynamicRange` (`"hdr"`/`"sdr"`) prop on the mpv player, set alongside `source`, plus a
+  staged `supportsHdr` prop (the panel's HDR capability, plumbed for a future display-gated decision but not
+  yet consulted). Both are exposed on iOS and Android for a 1:1 contract; **iOS/tvOS accept them but are
+  unaffected** (they already drive HDR via their own display-criteria path).
+- The letterbox now tracks the video's real display size via mpv `dwidth`/`dheight` observers (the first read
+  can be a placeholder before the frame decodes), deduped so it never churns the surface.
+
+### Verification
+- Android-only behavior change; iOS/tvOS/desktop paths are untouched. Needs an on-device check on Android TV
+  (Fire TV): HDR direct-play letterboxes without zoom, seeking back across a bumper into HDR content does not
+  restart from 0, no reconfigure flicker or badge flip, and SDR is unchanged.
+
 ## [0.13.20] - 2026-09-10
 
 Server — surface a program's HDR/dynamic-range on the playback resolve endpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Airwave are documented here.
 
+## [0.13.20] - 2026-09-10
+
+Server — surface a program's HDR/dynamic-range on the playback resolve endpoint.
+
+### Added
+- **`hdr` on the media resolve response.** `GET /api/v1/channels/:id/media` (`resolveMedia`) now returns
+  the program's dynamic range read from `MediaItem.guide.hdr` (`"HDR10"` / `"Dolby Vision"` / `"HLG"`, else
+  `null` for SDR), alongside the existing stream decision and Dolby Vision metadata. It rides on the same
+  `guide` read that already backed `dovi`, so there's no new column, endpoint, or query.
+
+### Why
+- A client can now pick its video-output path **up front at load time** from a fact the server already
+  knows, instead of detecting on the first decoded frame. This is the plumbing for the Android mpv HDR work
+  (choose `mediacodec_embed` for HDR vs `gpu-next` for SDR at the load boundary). It naturally covers both
+  direct-play and transcode, since the response is where that decision is already made.
+
 ## [0.13.19] - 2026-09-09
 
 Server tooling — a per-device playback-log inspector.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to Airwave are documented here.
 
+## [0.13.23] - 2026-09-10
+
+Android TV — fix the HDR letterbox sizing/positioning (center the surface ourselves; reset cleanly for SDR).
+
+### Fixed
+- **HDR video was mis-sized** — variously stretched, or letterboxed but pinned to the top/left corner (bars
+  only on the bottom/right), and the wrong geometry **persisted into the next program (even SDR) until the
+  channel was fully closed and reopened.** Root cause: the aspect container relied on two things that don't
+  hold inside a React Native native view — Android `layout_gravity` for centering (RN lays a native view's
+  children out itself and ignores gravity → off-center), and `requestLayout()` to re-fit (RN's UIManager
+  owns the layout pass and doesn't re-lay-out a native ViewGroup's children → the fit stuck until a remount).
+- The player now **sizes and centers the SurfaceView itself**: it overrides `requestLayout()` to post a
+  manual `measure`/`layout` (the documented RN Android workaround) and centers the surface explicitly, so an
+  aspect change — or the reset to full-screen — takes effect immediately. SDR (and mini-player) leave the
+  surface **full-screen**, exactly as before 0.13.19, so mpv's own gpu-next renderer letterboxes it; only the
+  HDR path (`mediacodec_embed`, which ignores mpv's aspect handling) is letterboxed at the view layer.
+
+### Diagnostics
+- Added `applyAspect`, `surfaceChanged`, and `layout surface …` logcat lines (tag `MpvCore`) to make the
+  view-layer sizing observable on device.
+
 ## [0.13.22] - 2026-09-10
 
 Android TV — restrict the view-layer letterbox to the HDR path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Airwave are documented here.
 
+## [0.13.22] - 2026-09-10
+
+Android TV — restrict the view-layer letterbox to the HDR path.
+
+### Fixed
+- The view-layer aspect letterbox now applies **only on the HDR video output** (`mediacodec_embed`, which
+  ignores mpv's keepaspect/panscan). On SDR, mpv's own renderer (gpu-next) already letterboxes correctly
+  inside the full-screen surface, so the container is left filling — avoiding a redundant SurfaceView resize
+  (and the `surfaceChanged` churn it caused) on every SDR program. This was the documented intent of the
+  container-letterbox all along; it had been applied to all content.
+
 ## [0.13.21] - 2026-09-10
 
 Android TV — pick the mpv video output UP FRONT from the program's known dynamic range (HDR fix).

--- a/apps/desktop-setup/package.json
+++ b/apps/desktop-setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airwave/desktop-setup",
-  "version": "0.13.20",
+  "version": "0.13.21",
   "private": true,
   "type": "module",
   "description": "Airwave Desktop first-run onboarding / settings UI — a small Vite + React app built with @airwave/ui (shadcn + oklch theme), rendered in the desktop app's native webview and driven by the supervisor's /config, /save, /status endpoints.",

--- a/apps/desktop-setup/package.json
+++ b/apps/desktop-setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airwave/desktop-setup",
-  "version": "0.13.19",
+  "version": "0.13.20",
   "private": true,
   "type": "module",
   "description": "Airwave Desktop first-run onboarding / settings UI — a small Vite + React app built with @airwave/ui (shadcn + oklch theme), rendered in the desktop app's native webview and driven by the supervisor's /config, /save, /status endpoints.",

--- a/apps/desktop-setup/package.json
+++ b/apps/desktop-setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airwave/desktop-setup",
-  "version": "0.13.22",
+  "version": "0.13.23",
   "private": true,
   "type": "module",
   "description": "Airwave Desktop first-run onboarding / settings UI — a small Vite + React app built with @airwave/ui (shadcn + oklch theme), rendered in the desktop app's native webview and driven by the supervisor's /config, /save, /status endpoints.",

--- a/apps/desktop-setup/package.json
+++ b/apps/desktop-setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airwave/desktop-setup",
-  "version": "0.13.21",
+  "version": "0.13.22",
   "private": true,
   "type": "module",
   "description": "Airwave Desktop first-run onboarding / settings UI — a small Vite + React app built with @airwave/ui (shadcn + oklch theme), rendered in the desktop app's native webview and driven by the supervisor's /config, /save, /status endpoints.",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.13.20",
+  "version": "0.13.21",
   "private": true,
   "type": "module",
   "description": "Airwave Desktop — an Electrobun tray-only supervisor that runs embedded Postgres + the Airwave server + admin + tv-web on local ports, next to Plex. The browser is the UI. See .plans/desktop-server.md.",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.13.21",
+  "version": "0.13.22",
   "private": true,
   "type": "module",
   "description": "Airwave Desktop — an Electrobun tray-only supervisor that runs embedded Postgres + the Airwave server + admin + tv-web on local ports, next to Plex. The browser is the UI. See .plans/desktop-server.md.",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.13.19",
+  "version": "0.13.20",
   "private": true,
   "type": "module",
   "description": "Airwave Desktop — an Electrobun tray-only supervisor that runs embedded Postgres + the Airwave server + admin + tv-web on local ports, next to Plex. The browser is the UI. See .plans/desktop-server.md.",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.13.22",
+  "version": "0.13.23",
   "private": true,
   "type": "module",
   "description": "Airwave Desktop — an Electrobun tray-only supervisor that runs embedded Postgres + the Airwave server + admin + tv-web on local ports, next to Plex. The browser is the UI. See .plans/desktop-server.md.",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.13.19",
+  "version": "0.13.20",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.13.22",
+  "version": "0.13.23",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.13.21",
+  "version": "0.13.22",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.13.20",
+  "version": "0.13.21",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "site",
-  "version": "0.13.22",
+  "version": "0.13.23",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "site",
-  "version": "0.13.20",
+  "version": "0.13.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "site",
-  "version": "0.13.21",
+  "version": "0.13.22",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "site",
-  "version": "0.13.19",
+  "version": "0.13.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/tv-native/app.json
+++ b/apps/tv-native/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Airwave",
     "slug": "airwave",
-    "version": "0.13.19",
+    "version": "0.13.20",
     "scheme": "airwave",
     "orientation": "landscape",
     "userInterfaceStyle": "dark",

--- a/apps/tv-native/app.json
+++ b/apps/tv-native/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Airwave",
     "slug": "airwave",
-    "version": "0.13.20",
+    "version": "0.13.21",
     "scheme": "airwave",
     "orientation": "landscape",
     "userInterfaceStyle": "dark",

--- a/apps/tv-native/app.json
+++ b/apps/tv-native/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Airwave",
     "slug": "airwave",
-    "version": "0.13.21",
+    "version": "0.13.22",
     "scheme": "airwave",
     "orientation": "landscape",
     "userInterfaceStyle": "dark",

--- a/apps/tv-native/app.json
+++ b/apps/tv-native/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Airwave",
     "slug": "airwave",
-    "version": "0.13.22",
+    "version": "0.13.23",
     "scheme": "airwave",
     "orientation": "landscape",
     "userInterfaceStyle": "dark",

--- a/apps/tv-native/package.json
+++ b/apps/tv-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-native",
-  "version": "0.13.22",
+  "version": "0.13.23",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {

--- a/apps/tv-native/package.json
+++ b/apps/tv-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-native",
-  "version": "0.13.21",
+  "version": "0.13.22",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {

--- a/apps/tv-native/package.json
+++ b/apps/tv-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-native",
-  "version": "0.13.19",
+  "version": "0.13.20",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {

--- a/apps/tv-native/package.json
+++ b/apps/tv-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-native",
-  "version": "0.13.20",
+  "version": "0.13.21",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {

--- a/apps/tv-native/src/features/watch/player-context.tsx
+++ b/apps/tv-native/src/features/watch/player-context.tsx
@@ -1,4 +1,4 @@
-import { MpvPlayerView } from "@airwave/mpv-player";
+import { MpvPlayerView, mpvDisplay } from "@airwave/mpv-player";
 import { Maximize2, X } from "lucide-react-native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ActivityIndicator, Platform, StyleSheet, Text, useWindowDimensions, View } from "react-native";
@@ -177,6 +177,9 @@ function PlayerHost({
   // Device audio-output pref (Settings → Audio). Reactive: flipping it reloads the current program with
   // the new mpv `audio-channels` (see useTvPlayer's reload key + the MpvPlayerView `audioMode` prop).
   const audioMode = useAudioMode();
+  // The panel's HDR capability (Android Display probe; null off Android → false). A device constant, staged
+  // for the future display-gated VO decision — the native side stores but doesn't yet consult it.
+  const supportsHdr = useMemo(() => mpvDisplay.getInfo()?.hdr ?? false, []);
   const [qualities, setQualities] = useState<{ id: string; label: string }[]>([]);
   useEffect(() => {
     api.qualities().then((r) => setQualities(r.qualities)).catch(() => {});
@@ -247,7 +250,7 @@ function PlayerHost({
         // Subtitles OFF by default: mpv otherwise auto-selects the embedded/forced sub track (sid=auto).
         // In this app subs are delivered by SERVER burn-in (selecting them re-resolves to a transcode
         // that hardcodes them into the video), so mpv must never render a text sub track itself.
-        <MpvPlayerView ref={tv.viewRef} source={tv.source} startTime={tv.startTime} mode={tv.mode} audioMode={audioMode} options={{ sid: "no", "sub-auto": "no" }} {...tv.videoEvents} style={StyleSheet.absoluteFill} contentFit={full ? "contain" : "cover"} />
+        <MpvPlayerView ref={tv.viewRef} source={tv.source} startTime={tv.startTime} mode={tv.mode} dynamicRange={tv.dynamicRange} supportsHdr={supportsHdr} audioMode={audioMode} options={{ sid: "no", "sub-auto": "no" }} {...tv.videoEvents} style={StyleSheet.absoluteFill} contentFit={full ? "contain" : "cover"} />
       )}
 
       {/* bumper interstitial — full (blurred art + big title + donut) or compact (mini feed) */}

--- a/apps/tv-native/src/features/watch/use-tv-player.ts
+++ b/apps/tv-native/src/features/watch/use-tv-player.ts
@@ -114,6 +114,11 @@ export function useTvPlayer(channelId: string | null, options: PlayerOptions = {
   // Content mode for the single hybrid engine: "video" for programs, "audio" for the bumper music bed (and
   // future radio). Set alongside `source`; the view applies it per-load. See .plans/mpv-hybrid-core.md.
   const [mode, setMode] = useState<"video" | "audio">("video");
+  // The current program's dynamic range (server `guide.hdr` → "hdr"/"sdr"), set alongside `source` on a
+  // PROGRAM load. The Android player picks the mpv VO up front from it (mediacodec_embed for HDR vs gpu-next),
+  // so there's no first-frame HDR detect / re-open. Bumper/audio loads deliberately DON'T update it — and the
+  // native side ignores it for audio mode anyway — so an HDR→bumper→HDR run never churns the VO. iOS ignores it.
+  const [dynamicRange, setDynamicRange] = useState<"hdr" | "sdr">("sdr");
   const positionSecRef = useRef(0); // latest onProgress currentTime (seconds); the effectiveTime clock reads this
   const playingRef = useRef(false);
   // audioMode is client-side only (mpv output layout — not a server param), but it's in the reload key so
@@ -281,6 +286,9 @@ export function useTvPlayer(channelId: string | null, options: PlayerOptions = {
         currentRef.current = loaded;
         pausedRef.current = false;
         setTracks({ audio: info.audioTracks, subtitle: info.subtitleTracks });
+        // Pick the VO up front on Android: this program's known dynamic range (server guide.hdr). Set with
+        // `source` below so it's coalesced into the single native load(). SDR when absent.
+        setDynamicRange(info.hdr ? "hdr" : "sdr");
         // mpv loads by setting the source prop; `startTime` opens direct-play AT the offset (loadfile
         // start=). Baseline is set in onLoad/onFirstFrame — see the event handlers below.
         logCtxRef.current = {
@@ -745,5 +753,5 @@ export function useTvPlayer(channelId: string | null, options: PlayerOptions = {
     [onLoad, onFirstFrame, onProgress, onBuffering, onError, onEnd],
   );
 
-  return { viewRef, source, startTime, mode, videoEvents, status, controls, tracks, titleOf };
+  return { viewRef, source, startTime, mode, dynamicRange, videoEvents, status, controls, tracks, titleOf };
 }

--- a/apps/tv-native/src/lib/api.ts
+++ b/apps/tv-native/src/lib/api.ts
@@ -182,6 +182,10 @@ export type MediaInfo = {
   audioTracks: Track[];
   subtitleTracks: Track[];
   decision?: { videoDecision?: string; audioDecision?: string; videoCodec?: string; audioCodec?: string; container?: string };
+  /** The program's dynamic range (server-derived from the video stream's colorTrc/DOVI → MediaItem.guide.hdr):
+   *  "HDR10" | "Dolby Vision" | "HLG" when HDR, else undefined. The Android player uses this to pick the mpv VO
+   *  up front at load (HDR → mediacodec_embed). See .plans/android-hdr-vo-predetect.md. */
+  hdr?: string;
   /** Dolby Vision metadata (captured from Plex). Plumbed to the client but NOT yet consumed — the
    *  native DV-mode switch (dvh1 display criteria on tvOS) is a deferred step. See .plans/tv-native.md §11. */
   dovi?: { profile: number; level?: number; blCompatId?: number };

--- a/apps/tv-roku/manifest
+++ b/apps/tv-roku/manifest
@@ -3,7 +3,7 @@ title=Airwave
 # Version — kept in lockstep with the other apps/* (see /version-bump). Mirrors package.json 0.12.0.
 major_version=0
 minor_version=13
-build_version=19
+build_version=20
 
 # Icons = branded logo mark on the radial gradient (home-screen tile). Splash = a FLAT #060a14 fill (Roku
 # requires a splash image, but ours hands off seamlessly to the in-app animated LogoLockup, which fades the

--- a/apps/tv-roku/manifest
+++ b/apps/tv-roku/manifest
@@ -3,7 +3,7 @@ title=Airwave
 # Version — kept in lockstep with the other apps/* (see /version-bump). Mirrors package.json 0.12.0.
 major_version=0
 minor_version=13
-build_version=20
+build_version=21
 
 # Icons = branded logo mark on the radial gradient (home-screen tile). Splash = a FLAT #060a14 fill (Roku
 # requires a splash image, but ours hands off seamlessly to the in-app animated LogoLockup, which fades the

--- a/apps/tv-roku/manifest
+++ b/apps/tv-roku/manifest
@@ -3,7 +3,7 @@ title=Airwave
 # Version — kept in lockstep with the other apps/* (see /version-bump). Mirrors package.json 0.12.0.
 major_version=0
 minor_version=13
-build_version=21
+build_version=22
 
 # Icons = branded logo mark on the radial gradient (home-screen tile). Splash = a FLAT #060a14 fill (Roku
 # requires a splash image, but ours hands off seamlessly to the in-app animated LogoLockup, which fades the

--- a/apps/tv-roku/manifest
+++ b/apps/tv-roku/manifest
@@ -3,7 +3,7 @@ title=Airwave
 # Version — kept in lockstep with the other apps/* (see /version-bump). Mirrors package.json 0.12.0.
 major_version=0
 minor_version=13
-build_version=22
+build_version=23
 
 # Icons = branded logo mark on the radial gradient (home-screen tile). Splash = a FLAT #060a14 fill (Roku
 # requires a splash image, but ours hands off seamlessly to the in-app animated LogoLockup, which fades the

--- a/apps/tv-roku/package.json
+++ b/apps/tv-roku/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-roku",
-  "version": "0.13.22",
+  "version": "0.13.23",
   "private": true,
   "description": "Airwave Roku client (BrighterScript + SceneGraph). A direct port of tv-web/tv-native to Roku — strict visual + functional parity, its own separately-maintained codebase.",
   "scripts": {

--- a/apps/tv-roku/package.json
+++ b/apps/tv-roku/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-roku",
-  "version": "0.13.21",
+  "version": "0.13.22",
   "private": true,
   "description": "Airwave Roku client (BrighterScript + SceneGraph). A direct port of tv-web/tv-native to Roku — strict visual + functional parity, its own separately-maintained codebase.",
   "scripts": {

--- a/apps/tv-roku/package.json
+++ b/apps/tv-roku/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-roku",
-  "version": "0.13.20",
+  "version": "0.13.21",
   "private": true,
   "description": "Airwave Roku client (BrighterScript + SceneGraph). A direct port of tv-web/tv-native to Roku — strict visual + functional parity, its own separately-maintained codebase.",
   "scripts": {

--- a/apps/tv-roku/package.json
+++ b/apps/tv-roku/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-roku",
-  "version": "0.13.19",
+  "version": "0.13.20",
   "private": true,
   "description": "Airwave Roku client (BrighterScript + SceneGraph). A direct port of tv-web/tv-native to Roku — strict visual + functional parity, its own separately-maintained codebase.",
   "scripts": {

--- a/apps/tv-tauri/package.json
+++ b/apps/tv-tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-tauri",
-  "version": "0.13.20",
+  "version": "0.13.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/tv-tauri/package.json
+++ b/apps/tv-tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-tauri",
-  "version": "0.13.21",
+  "version": "0.13.22",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/tv-tauri/package.json
+++ b/apps/tv-tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-tauri",
-  "version": "0.13.22",
+  "version": "0.13.23",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/tv-tauri/package.json
+++ b/apps/tv-tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-tauri",
-  "version": "0.13.19",
+  "version": "0.13.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/tv-tauri/src-tauri/Cargo.lock
+++ b/apps/tv-tauri/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "airwave"
-version = "0.13.22"
+version = "0.13.23"
 dependencies = [
  "futures",
  "if-addrs",

--- a/apps/tv-tauri/src-tauri/Cargo.lock
+++ b/apps/tv-tauri/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "airwave"
-version = "0.13.21"
+version = "0.13.22"
 dependencies = [
  "futures",
  "if-addrs",

--- a/apps/tv-tauri/src-tauri/Cargo.lock
+++ b/apps/tv-tauri/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "airwave"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "futures",
  "if-addrs",

--- a/apps/tv-tauri/src-tauri/Cargo.lock
+++ b/apps/tv-tauri/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "airwave"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "futures",
  "if-addrs",

--- a/apps/tv-tauri/src-tauri/Cargo.toml
+++ b/apps/tv-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "airwave"
-version = "0.13.22"
+version = "0.13.23"
 description = "Airwave desktop client (Tauri + libmpv)"
 authors = ["Airwave"]
 license = ""

--- a/apps/tv-tauri/src-tauri/Cargo.toml
+++ b/apps/tv-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "airwave"
-version = "0.13.21"
+version = "0.13.22"
 description = "Airwave desktop client (Tauri + libmpv)"
 authors = ["Airwave"]
 license = ""

--- a/apps/tv-tauri/src-tauri/Cargo.toml
+++ b/apps/tv-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "airwave"
-version = "0.13.19"
+version = "0.13.20"
 description = "Airwave desktop client (Tauri + libmpv)"
 authors = ["Airwave"]
 license = ""

--- a/apps/tv-tauri/src-tauri/Cargo.toml
+++ b/apps/tv-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "airwave"
-version = "0.13.20"
+version = "0.13.21"
 description = "Airwave desktop client (Tauri + libmpv)"
 authors = ["Airwave"]
 license = ""

--- a/apps/tv-tauri/src-tauri/tauri.conf.json
+++ b/apps/tv-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Airwave Client",
-  "version": "0.13.22",
+  "version": "0.13.23",
   "identifier": "com.airwave.tvdesktop",
   "build": {
     "frontendDist": "../dist",

--- a/apps/tv-tauri/src-tauri/tauri.conf.json
+++ b/apps/tv-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Airwave Client",
-  "version": "0.13.21",
+  "version": "0.13.22",
   "identifier": "com.airwave.tvdesktop",
   "build": {
     "frontendDist": "../dist",

--- a/apps/tv-tauri/src-tauri/tauri.conf.json
+++ b/apps/tv-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Airwave Client",
-  "version": "0.13.19",
+  "version": "0.13.20",
   "identifier": "com.airwave.tvdesktop",
   "build": {
     "frontendDist": "../dist",

--- a/apps/tv-tauri/src-tauri/tauri.conf.json
+++ b/apps/tv-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Airwave Client",
-  "version": "0.13.20",
+  "version": "0.13.21",
   "identifier": "com.airwave.tvdesktop",
   "build": {
     "frontendDist": "../dist",

--- a/apps/tv-web/package.json
+++ b/apps/tv-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-web",
-  "version": "0.13.19",
+  "version": "0.13.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/tv-web/package.json
+++ b/apps/tv-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-web",
-  "version": "0.13.20",
+  "version": "0.13.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/tv-web/package.json
+++ b/apps/tv-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-web",
-  "version": "0.13.21",
+  "version": "0.13.22",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/tv-web/package.json
+++ b/apps/tv-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-web",
-  "version": "0.13.22",
+  "version": "0.13.23",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/tv-web/public/appinfo.json
+++ b/apps/tv-web/public/appinfo.json
@@ -1,6 +1,6 @@
 {
   "id": "com.airwave.tv",
-  "version": "0.13.22",
+  "version": "0.13.23",
   "vendor": "Airwave",
   "type": "web",
   "main": "index.html",

--- a/apps/tv-web/public/appinfo.json
+++ b/apps/tv-web/public/appinfo.json
@@ -1,6 +1,6 @@
 {
   "id": "com.airwave.tv",
-  "version": "0.13.19",
+  "version": "0.13.20",
   "vendor": "Airwave",
   "type": "web",
   "main": "index.html",

--- a/apps/tv-web/public/appinfo.json
+++ b/apps/tv-web/public/appinfo.json
@@ -1,6 +1,6 @@
 {
   "id": "com.airwave.tv",
-  "version": "0.13.20",
+  "version": "0.13.21",
   "vendor": "Airwave",
   "type": "web",
   "main": "index.html",

--- a/apps/tv-web/public/appinfo.json
+++ b/apps/tv-web/public/appinfo.json
@@ -1,6 +1,6 @@
 {
   "id": "com.airwave.tv",
-  "version": "0.13.21",
+  "version": "0.13.22",
   "vendor": "Airwave",
   "type": "web",
   "main": "index.html",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.13.21",
+  "version": "0.13.22",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.13.22",
+  "version": "0.13.23",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.13.20",
+  "version": "0.13.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.13.19",
+  "version": "0.13.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/src/services/playback/broker.ts
+++ b/packages/api/src/services/playback/broker.ts
@@ -99,20 +99,30 @@ export async function resolveMedia(
   );
   if (!info) throw notFound("No playable media part.");
 
-  // Dolby Vision metadata (captured at sync → MediaItem.guide.dovi). Passed through so the native
-  // player CAN switch the Apple TV into DV mode (dvh1 display criteria) — that consumer is a later,
-  // tvOS-only step; for now it's plumbed but unused. See .plans/tv-native.md §11 (DV arc).
+  // Color/HDR metadata captured at sync onto MediaItem.guide.
+  //  - `hdr`: the program's dynamic range (defacto-correct from the video stream's colorTrc/DOVI;
+  //    "HDR10" | "Dolby Vision" | "HLG", else null for SDR). The Android mpv core reads this at LOAD
+  //    to pick the VO UP FRONT (mediacodec_embed for HDR, gpu-next for SDR) — no first-frame probe,
+  //    no mid-stream re-open. See .plans/android-hdr-vo-predetect.md.
+  //  - `dovi`: Dolby Vision profile/level, so the native player CAN switch the Apple TV into DV mode
+  //    (dvh1 display criteria) — that consumer is a later, tvOS-only step. See .plans/tv-native.md §11.
   const item = await prisma.mediaItem.findUnique({
     where: { mediaSourceId_ratingKey: { mediaSourceId: source.id, ratingKey } },
     select: { guide: true },
   });
-  const dovi = (item?.guide as { dovi?: { profile: number; level?: number; blCompatId?: number } } | null)?.dovi;
+  const guide = item?.guide as {
+    hdr?: "HDR10" | "Dolby Vision" | "HLG" | null;
+    dovi?: { profile: number; level?: number; blCompatId?: number };
+  } | null;
+  const hdr = guide?.hdr ?? null;
+  const dovi = guide?.dovi;
 
   return {
     ...info,
     offsetSeconds,
     connection,
     capsSource: measured ? "measured" : opts.caps ? "reported" : "default",
+    hdr,
     ...(dovi ? { dovi } : {}),
   };
 }

--- a/packages/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvCore.kt
+++ b/packages/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvCore.kt
@@ -21,6 +21,10 @@ import kotlin.math.abs
 /** Events surfaced from the mpv flows up to the Expo view (mirrors the iOS `MpvCoreDelegate`). */
 interface MpvCoreDelegate {
   fun mpvDidLoad(duration: Double, width: Int, height: Int)
+  /** The video's real display size (mpv `dwidth`/`dheight`, PAR-correct) once it's known/updated. Drives the
+   *  view's aspect letterbox. Fires as the size settles after load, because the first `dwidth`/`dheight` read
+   *  can be a placeholder (e.g. 960x540 on a Fire TV) before the real frame decodes. */
+  fun mpvVideoSize(width: Int, height: Int)
   fun mpvFirstFrame()
   fun mpvProgress(time: Double, duration: Double)
   fun mpvBuffering(buffering: Boolean)
@@ -40,13 +44,6 @@ interface MpvCoreDelegate {
  * (whose Android HDR lives on its ExoPlayer path, not mpv).
  */
 class MpvCore(private val appContext: Context) {
-  companion object {
-    // Master switch for the dynamic HDR (mediacodec_embed) path. Was briefly gated off (v0.11.75) to rule
-    // it out of a diagnostic freeze — the HDR-off build still froze, so HDR is cleared (the freeze was the
-    // diagnostic's per-clip mpv teardown leak, fixed separately by reusing one instance). Back ON.
-    private const val HDR_SWITCH_ENABLED = true
-  }
-
   var delegate: MpvCoreDelegate? = null
 
   // The SDR video output. gpu-next (libplacebo, mpv's own renderer) is the default and is better everywhere
@@ -56,22 +53,29 @@ class MpvCore(private val appContext: Context) {
   // mpv #14934, findroid #686). The classic `gpu` renderer keeps hardware decoding and renders correctly
   // there. HDR is unaffected — it uses mediacodec_embed (a different path that already works on the Shield),
   // so ONLY the SDR VO changes, and ONLY on the Shield. HDR was never gpu-next's job on Android (that VO
-  // can't passthrough HDR — it tone-maps; the real HDR path is mediacodec_embed, see maybeSwitchHdr).
+  // can't passthrough HDR — it tone-maps; the real HDR path is mediacodec_embed, see applyVoForLoad).
   private val sdrVo = if (isNvidiaShield()) "gpu" else "gpu-next"
 
-  // The video output, chosen DYNAMICALLY per program (§13.5). `sdrVo` is the SDR default (mpv's own renderer:
-  // gpu-next everywhere, `gpu` on the Shield — see above). On Android, gpu-next's OpenGL-ES path CANNOT
-  // passthrough HDR — it ALWAYS tone-maps HDR→SDR (findroid #645, mpv-android #874, libplacebo author). So on
-  // the first decoded frame we detect HDR (`video-params/sig-peak`/`max-luma`) and, for HDR content, switch to
-  // `vo=mediacodec_embed` (MediaCodec renders straight to the SurfaceView = real HDR10/HLG passthrough + full
-  // frame rate) and re-open the file at the same offset — exactly mirroring the Apple side, which reads gamma
-  // on first frame to drive its display switch. `currentVo` is a var because it changes at runtime;
-  // `attachSurface` restores IT (not a const) so an HDR program survives a surface reposition. (Do NOT
-  // global-force `mediacodec_embed` — tried v0.9.1, reverted v0.9.2: it regresses SDR, which must stay on
-  // mpv's renderer.)
+  // The video output, chosen UP FRONT per program (see applyVoForLoad + .plans/android-hdr-vo-predetect.md).
+  // On Android, gpu-next's OpenGL-ES path CANNOT passthrough HDR — it ALWAYS tone-maps HDR→SDR (findroid #645,
+  // mpv-android #874, libplacebo author). So for HDR content — known IN ADVANCE from the server's
+  // `MediaItem.guide.hdr` (passed in as the `dynamicRange` load arg) — we open on `vo=mediacodec_embed` (+
+  // zero-copy `hwdec=mediacodec` — the MediaCodec→SurfaceView path = real HDR10/HLG/DV passthrough + full
+  // frame rate); SDR opens on `sdrVo`. The VO is set at the LOAD boundary, BEFORE that program's loadfile —
+  // NOT detected on the first decoded frame and re-opened. (The first-frame detect + `loadfile replace`
+  // re-open caused seek-back restart-from-0 + a surface-reconfigure flicker/badge-flip; it was scrapped — see
+  // the plan.) Because each program is its own loadfile, there is NO mid-stream switch → no restart, no churn.
+  // `currentVo` is a var: applyVoForLoad updates it per program, and `attachSurface` restores IT (not a const)
+  // so an HDR program on mediacodec_embed survives a surface reposition (mini↔full). (Do NOT global-force
+  // `mediacodec_embed` — tried v0.9.1, reverted v0.9.2: it regresses SDR, which must stay on mpv's renderer.)
   private var currentVo = sdrVo
-  // One HDR probe per user load (reset in load()); the internal re-open under the new VO must NOT re-probe.
-  private var hdrChecked = false
+
+  // The panel's HDR capability (from the client's display probe / TvDevice.hdr). PLUMBED but NOT yet
+  // consulted — the VO decision currently uses CONTENT HDR only. Gating the passthrough on the display later
+  // (HDR content on an SDR panel → gpu-next tone-map) becomes a one-line change in applyVoForLoad. See
+  // .plans/android-hdr-vo-predetect.md §7 (stretch goal).
+  @Suppress("unused")
+  private var supportsHdr = false
 
   // A single scope drives create + all Flow collectors. MpvPlayer's suspend calls submit through its own
   // internal single-threaded native dispatcher, so ordering (options → loadfile) is preserved for us.
@@ -80,6 +84,9 @@ class MpvCore(private val appContext: Context) {
   private var pendingSurface: Surface? = null
   private var loadedEmitted = false
   private var firstFrameEmitted = false
+  // Last video display size pushed to the view (dedup for pushVideoSize). Reset per user load().
+  private var lastSizeW = 0
+  private var lastSizeH = 0
   // Last commanded volume in mpv units (0..100); a fade resumes from here. The hybrid single engine shares
   // this ONE `volume` between video (full) and audio-only bumper/radio content — a video load resets it.
   private var currentVolume = 100.0
@@ -90,6 +97,12 @@ class MpvCore(private val appContext: Context) {
   private var pendingLoadUrl: String? = null
   private var pendingLoadStart: Double = 0.0
   private var pendingLoadMode: String = "video"
+  // The program's dynamic range for the NEXT load ("hdr"|"sdr", or null = leave the VO alone: bumper/audio).
+  // Set alongside url/start/mode; read by applyVoForLoad to pick the VO BEFORE the loadfile.
+  private var pendingLoadDynamicRange: String? = null
+
+  /** Stage the panel's HDR capability (see `supportsHdr`). Stored; not yet consulted by the VO decision. */
+  fun setSupportsHdr(supported: Boolean) { supportsHdr = supported }
 
   // MARK: setup
 
@@ -98,8 +111,9 @@ class MpvCore(private val appContext: Context) {
     scope.launch {
       val p = try {
         MpvPlayer.create(appContext) {
-          // Android render path — the mpv-android / findroid recipe. Starts on gpu-next (SDR); HDR content
-          // is detected on first frame and re-opened under mediacodec_embed (see maybeSwitchHdr).
+          // Android render path — the mpv-android / findroid recipe. Opens on the SDR VO; a program known to
+          // be HDR (from the server's guide.hdr) switches to mediacodec_embed at its load boundary, up front
+          // (see applyVoForLoad) — no first-frame detect, no re-open.
           setOption("vo", currentVo)
           setOption("gpu-context", "android")
           setOption("opengl-es", "yes")
@@ -146,14 +160,22 @@ class MpvCore(private val appContext: Context) {
         delegate?.mpvProgress(t, dur)
       }.launchIn(scope)
       p.observeFlag("paused-for-cache").onEach { delegate?.mpvBuffering(it) }.launchIn(scope)
+      // Drive the aspect letterbox off the REAL display size, reacting the instant it changes (the first read
+      // after playback starts can be a placeholder before the frame decodes). Both feed the same dedup'd push.
+      p.observeDouble("dwidth").onEach { pushVideoSize() }.launchIn(scope)
+      p.observeDouble("dheight").onEach { pushVideoSize() }.launchIn(scope)
 
       p.eventFlow.onEach { handleEvent(it) }.launchIn(scope)
       // Forward mpv's own logs to logcat (`adb logcat -s MpvCore`) — invaluable for diagnosing
       // no-frame / decode / VO / HDR issues on device.
       p.logFlow.onEach { android.util.Log.i("MpvCore", "[${it.level}] ${it.prefix}: ${it.text}") }.launchIn(scope)
 
-      // A load() may have been requested before create() finished (create is suspend) — run it now.
-      pendingLoadUrl?.let { doLoad(p, it, pendingLoadStart, pendingLoadMode) }
+      // A load() may have been requested before create() finished (create is suspend) — run it now, picking
+      // the VO up front for the (possibly HDR) program before its loadfile.
+      pendingLoadUrl?.let {
+        applyVoForLoad(p, pendingLoadMode, pendingLoadDynamicRange)
+        doLoad(p, it, pendingLoadStart, pendingLoadMode)
+      }
     }
   }
 
@@ -163,29 +185,53 @@ class MpvCore(private val appContext: Context) {
    * Load `url`, opening AT `startTime` seconds. mpv 0.38+ loadfile is `loadfile <url> <flags> <index>
    * <options>` — the `-1` index MUST be present before options, or the options string lands in the index
    * slot, the command is malformed, and no file loads (silent). Matches plezy's `loadfile <uri> replace -1`.
+   *
+   * `dynamicRange` ("hdr"|"sdr") is the program's KNOWN dynamic range (server guide.hdr) — used to pick the
+   * VO UP FRONT via applyVoForLoad, before the loadfile. `null` (bumper/audio) leaves the VO untouched.
    */
-  fun load(url: String, startTime: Double, mode: String = "video") {
+  fun load(url: String, startTime: Double, mode: String = "video", dynamicRange: String? = null) {
     loadedEmitted = false
     firstFrameEmitted = false
-    hdrChecked = false
+    lastSizeW = 0
+    lastSizeH = 0
     fadeJob?.cancel()
     pendingLoadUrl = url
     pendingLoadStart = startTime
     pendingLoadMode = mode
+    pendingLoadDynamicRange = dynamicRange
     // If the player is already up, load immediately; otherwise setup()'s create() runs it on completion.
     val p = player ?: return
     scope.launch {
-      // Always probe HDR on mpv's own renderer: if a prior HDR program left us on mediacodec_embed, reset
-      // to the SDR VO (`sdrVo`: gpu-next, or `gpu` on the Shield) for a clean, reliable detect (its
-      // video-params are guaranteed). SDR then stays on `sdrVo`; HDR re-switches to embed on first frame
-      // (§13.5). Skipped for audio-only (vid=no) loads.
-      if (mode != "audio" && currentVo != sdrVo) {
-        currentVo = sdrVo
-        p.setProperty("hwdec", "mediacodec,mediacodec-copy")
-        p.setProperty("vo", sdrVo)
-      }
+      // Pick the VO for THIS program up front (HDR → mediacodec_embed, SDR → sdrVo), BEFORE the loadfile —
+      // no first-frame probe, no mid-stream switch, no re-open. Bumper/audio loads leave the VO as-is.
+      applyVoForLoad(p, mode, dynamicRange)
       doLoad(p, url, startTime, mode)
     }
+  }
+
+  /**
+   * Choose the video output for a load UP FRONT, from the program's known dynamic range (§2/§2a of
+   * .plans/android-hdr-vo-predetect.md). HDR → `vo=mediacodec_embed` (+ zero-copy `hwdec=mediacodec`) = real
+   * HDR10/HLG/DV passthrough; SDR → `sdrVo` (mpv's gpu-next, or `gpu` on the Shield). Set BEFORE the loadfile
+   * (no active decode at that moment) so there is no mid-stream switch, no destructive re-open, and no
+   * surface-reconfigure churn — the fatal flaws of the old first-frame detect + `loadfile replace` approach.
+   *
+   * Applied ONLY for program (non-audio) loads that carry a range, and only when the VO actually CHANGES
+   * (deduped on `currentVo`). Bumper/audio-only loads pass `dynamicRange=null` and NEVER touch the VO — so
+   * `HDR program → bumper → HDR program` stays on mediacodec_embed the whole way, with zero switches (matches
+   * iOS; avoids pointless HDR↔SDR churn across an interstitial). `supportsHdr` (the panel's HDR capability) is
+   * plumbed but not yet consulted here — see the plan's §7 stretch goal.
+   */
+  private suspend fun applyVoForLoad(p: MpvPlayer, mode: String, dynamicRange: String?) {
+    if (mode == "audio" || dynamicRange == null) return
+    val isHdr = dynamicRange == "hdr"
+    val neededVo = if (isHdr) "mediacodec_embed" else sdrVo
+    if (neededVo == currentVo) return
+    android.util.Log.i("MpvCore", "VO up-front: dynamicRange=$dynamicRange → vo=$neededVo (was $currentVo)")
+    currentVo = neededVo
+    // Embed needs the direct (zero-copy) mediacodec decoder; gpu-next uses the copy fallback too.
+    p.setProperty("hwdec", if (isHdr) "mediacodec" else "mediacodec,mediacodec-copy")
+    p.setProperty("vo", neededVo)
   }
 
   /**
@@ -384,11 +430,11 @@ class MpvCore(private val appContext: Context) {
     when (event) {
       is MpvEvent.FileLoaded -> scope.launch { maybeEmitLoad() }
       is MpvEvent.PlaybackRestart -> {
-        // A frame is now decoded → width/height AND the HDR color params are guaranteed. Emit onLoad (in
-        // case file-loaded didn't have dimensions yet), run the one-shot HDR probe (may re-open under
-        // mediacodec_embed), then the first-frame signal.
+        // A frame is now decoded → width/height are guaranteed. Emit onLoad (in case file-loaded didn't have
+        // dimensions yet), push the real display size (covers a new program whose size equals the last, where
+        // the dwidth/dheight observer wouldn't fire), then the first-frame signal.
         scope.launch { maybeEmitLoad() }
-        if (HDR_SWITCH_ENABLED) scope.launch { maybeSwitchHdr() }
+        scope.launch { pushVideoSize() }
         if (!firstFrameEmitted) {
           firstFrameEmitted = true
           delegate?.mpvFirstFrame()
@@ -430,54 +476,22 @@ class MpvCore(private val appContext: Context) {
   }
 
   /**
-   * The Android HDR switch (§13.5) — mirrors how `ios/MpvCore.swift` reads the video's gamma on first
-   * frame to drive its display switch. mpv's OpenGL-ES `gpu-next` path can't passthrough HDR (it tone-maps
-   * HDR→SDR), so for HDR content we swap to `vo=mediacodec_embed` (+ zero-copy `hwdec=mediacodec`) — the
-   * MediaCodec→SurfaceView path that IS real HDR10/HLG passthrough — and RE-OPEN the file at the same
-   * offset (a clean reload, not a fragile live VO flip). SDR stays on gpu-next (mpv's full renderer).
-   *
-   * Detection is numeric via `getDouble` (the AAR's confirmed getter): `video-params/sig-peak` (SDR ≈ 1.0;
-   * PQ/HLG > 1) with `video-params/max-luma` (mastering peak in cd/m², set for HDR10) as a hedge. Runs once
-   * per user load (`hdrChecked`); the internal re-open must not re-probe or it would loop.
+   * Read mpv's real display size (`dwidth`/`dheight`, PAR-correct) and push it to the view when it changes.
+   * Driven by the `dwidth`/`dheight` property observers (fires the instant the real frame decodes and the size
+   * updates from any placeholder — e.g. Fire TV MediaCodec briefly reports ~960x540) plus one read at
+   * PlaybackRestart (covers a new program whose size equals the last, where the observer wouldn't fire). No
+   * timer/poll, and dedup'd so it never churns the surface (which caused HDR reconfig flicker). The VO is now
+   * chosen up front (applyVoForLoad), so there is no mid-stream switch to re-fit against.
    */
-  private suspend fun maybeSwitchHdr() {
-    if (hdrChecked) return
+  private suspend fun pushVideoSize() {
     val p = player ?: return
-    // Audio-only loads (bumper bed / radio) have no video — never touch the VO.
-    if (pendingLoadMode == "audio") { hdrChecked = true; return }
-    hdrChecked = true
-
-    val sigPeak = p.getDouble("video-params/sig-peak") ?: 0.0
-    val maxLuma = p.getDouble("video-params/max-luma") ?: 0.0
-    val isHdr = sigPeak > 1.5 || maxLuma > 100.0
-    val neededVo = if (isHdr) "mediacodec_embed" else sdrVo
-    android.util.Log.i(
-      "MpvCore",
-      "HDR probe: sig-peak=$sigPeak max-luma=$maxLuma isHdr=$isHdr currentVo=$currentVo neededVo=$neededVo",
-    )
-    if (neededVo == currentVo) return
-
-    currentVo = neededVo
-    // Embed needs the direct (zero-copy) mediacodec decoder; gpu-next uses the copy fallback too.
-    p.setProperty("hwdec", if (isHdr) "mediacodec" else "mediacodec,mediacodec-copy")
-    p.setProperty("vo", neededVo)
-
-    // TRANSCODE (Plex HLS): switch the VO/decoder LIVE on the running stream — do NOT reload. Re-requesting
-    // the Plex session URL (`loadfile replace`) un-anchors it (offset lost) AND resets mpv's `time-pos`,
-    // which the JS channel clock depends on (it must stay session-relative + continuous). This mirrors how
-    // iOS switches the tvOS display for HDR without reloading. The live vo/hwdec set above reconfigures the
-    // output on the ongoing stream, leaving the stream — and thus the offset + time-pos + clock — untouched.
-    val isTranscode = pendingLoadUrl?.contains("/transcode/") == true
-    if (isTranscode) {
-      android.util.Log.i("MpvCore", "HDR switch (transcode) → live VO=$neededVo, no reload")
-      return
+    val w = (p.getDouble("dwidth") ?: 0.0).toInt()
+    val h = (p.getDouble("dheight") ?: 0.0).toInt()
+    if (w > 0 && h > 0 && (w != lastSizeW || h != lastSizeH)) {
+      lastSizeW = w
+      lastSizeH = h
+      android.util.Log.i("MpvCore", "video size → ${w}x${h}")
+      delegate?.mpvVideoSize(w, h)
     }
-
-    // DIRECT-PLAY: the URL is a real file, so `loadfile … start=` re-seeks it cleanly. Clamp to ≥ the
-    // originally requested start so an early HDR probe (time-pos not yet settled) can't regress the offset.
-    val pos = maxOf(p.getDouble("time-pos") ?: 0.0, pendingLoadStart)
-    pendingLoadStart = pos
-    android.util.Log.i("MpvCore", "HDR switch → re-opening on $neededVo at ${pos}s")
-    pendingLoadUrl?.let { doLoad(p, it, pos, pendingLoadMode) }
   }
 }

--- a/packages/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvPlayerModule.kt
+++ b/packages/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvPlayerModule.kt
@@ -93,6 +93,11 @@ class MpvPlayerModule : Module() {
       // triggers the coalesced load. (DVR seeks go through the imperative `seek` below, not startTime.)
       Prop("startTime") { view: MpvPlayerView, t: Double -> view.setPendingStartTime(t) }
       Prop("mode") { view: MpvPlayerView, mode: String -> view.setPendingMode(mode) }
+      // The program's dynamic range ("hdr"/"sdr", from the server's guide.hdr) — picks the mpv VO up front on
+      // Android (mediacodec_embed for HDR vs gpu-next for SDR); null (bumper/audio) leaves the VO. Set with source.
+      Prop("dynamicRange") { view: MpvPlayerView, range: String? -> view.setPendingHdr(range) }
+      // The panel's HDR capability — staged for the future display-gated VO decision; not yet consulted.
+      Prop("supportsHdr") { view: MpvPlayerView, supported: Boolean -> view.setSupportsHdr(supported) }
       Prop("source") { view: MpvPlayerView, source: String? -> view.setPendingSource(source) }
       Prop("paused") { view: MpvPlayerView, paused: Boolean -> view.setPaused(paused) }
       Prop("muted") { view: MpvPlayerView, muted: Boolean -> view.setMuted(muted) }

--- a/packages/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvPlayerView.kt
+++ b/packages/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvPlayerView.kt
@@ -33,6 +33,9 @@ class MpvPlayerView(context: Context, appContext: AppContext) :
   // Content mode for the NEXT load ("video" | "audio"). Set alongside `source` in one render, read by
   // applySource → core.load. Audio = the bumper music bed / radio (no video track, JS-driven volume).
   private var pendingMode: String = "video"
+  // Dynamic range for the NEXT load ("hdr" | "sdr" | null). Set alongside `source` (from the server's
+  // guide.hdr), read by applySource → core.load to pick the VO up front. null (bumper/audio) leaves the VO.
+  private var pendingDynamicRange: String? = null
   private var lastLoadedSource: String? = null
   private var applyScheduled = false
   private var disposed = false
@@ -40,11 +43,14 @@ class MpvPlayerView(context: Context, appContext: AppContext) :
   // hold during playback like iOS/tvOS, so without this a playing channel dims + sleeps.
   private var videoActive = false
 
-  // Video display dimensions (from mpvDidLoad, PAR-correct) + the requested fit, fed to videoContainer's
-  // aspect. The HDR VO `mediacodec_embed` renders the MediaCodec surface directly and ignores mpv's
-  // keepaspect/panscan (no mpv option fixes it — mpv-android#486), so a full-screen surface stretches
-  // non-16:9 content (e.g. 3840x2076 cinema → +4% taller). The container letterboxes it. The HDR re-open is
-  // also clamped to ≥ the seek offset (MpvCore.maybeSwitchHdr) so any surface reconfig can't drop the offset.
+  // Video display dimensions + the requested fit, fed to videoContainer's aspect. The HDR VO
+  // `mediacodec_embed` renders the MediaCodec surface directly and ignores mpv's keepaspect/panscan (no mpv
+  // option fixes it — mpv-android#486), so a full-screen surface stretches non-16:9 content (e.g. 3840x2076
+  // cinema → +4% taller). The container letterboxes it. The real display size arrives via `mpvVideoSize` (the
+  // core watches mpv's dwidth/dheight as they settle — the first read can be a placeholder like 960x540 before
+  // the frame decodes). That updates videoW/videoH and re-letterboxes. We do NOT force relayouts or run a
+  // global-layout listener: that churned the surface and caused HDR reconfig flicker; a real size change
+  // already triggers a relayout via setAspectRatio.
   private var videoW = 0
   private var videoH = 0
   private var contentFit = "contain"
@@ -112,8 +118,8 @@ class MpvPlayerView(context: Context, appContext: AppContext) :
 
   fun setPendingSource(source: String?) {
     pendingSource = source
-    // New program → dims unknown until its first frame; reset so applyAspect re-fits once mpvDidLoad reports
-    // the new dimensions, rather than reusing the previous program's.
+    // New program → dims unknown until its first frame; reset so applyAspect re-fits once the size is reported
+    // (via mpvVideoSize), rather than reusing the previous program's.
     videoW = 0
     videoH = 0
     applyAspect()
@@ -127,6 +133,19 @@ class MpvPlayerView(context: Context, appContext: AppContext) :
   fun setPendingMode(mode: String) {
     pendingMode = if (mode == "audio") "audio" else "video"
   }
+
+  /** The program's dynamic range for the next load — "hdr"/"sdr" (from the server's guide.hdr) picks the VO
+   *  up front; null (bumper/audio) leaves the VO untouched. Set alongside `source`; applied at applySource. */
+  fun setPendingHdr(dynamicRange: String?) {
+    pendingDynamicRange = when (dynamicRange) {
+      "hdr" -> "hdr"
+      "sdr" -> "sdr"
+      else -> null
+    }
+  }
+
+  /** The panel's HDR capability (staged for the future display-gated VO decision; not yet consulted). */
+  fun setSupportsHdr(supported: Boolean) = core.setSupportsHdr(supported)
 
   fun setContentFit(fit: String) {
     contentFit = fit
@@ -188,7 +207,7 @@ class MpvPlayerView(context: Context, appContext: AppContext) :
       surfaceView.keepScreenOn = false
       return
     }
-    core.load(src, pendingStartTime, pendingMode)
+    core.load(src, pendingStartTime, pendingMode, pendingDynamicRange)
     // Video playback keeps the screen awake (audio-only bumper/radio doesn't); paused state refines it.
     videoActive = pendingMode != "audio"
     surfaceView.keepScreenOn = videoActive
@@ -203,6 +222,19 @@ class MpvPlayerView(context: Context, appContext: AppContext) :
       applyAspect()
     }
     onLoad(mapOf("duration" to duration, "width" to width, "height" to height))
+  }
+
+  /**
+   * The real display size (mpv dwidth/dheight), pushed as it settles after load — the first read can be a
+   * placeholder (e.g. 960x540) before the frame decodes. Updating videoW/videoH re-letterboxes via applyAspect
+   * (the ratio change triggers the relayout). Runs on the UI thread (core scope = Main).
+   */
+  override fun mpvVideoSize(width: Int, height: Int) {
+    if (width > 0 && height > 0 && (width != videoW || height != videoH)) {
+      videoW = width
+      videoH = height
+      applyAspect()
+    }
   }
 
   override fun mpvFirstFrame() {

--- a/packages/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvPlayerView.kt
+++ b/packages/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvPlayerView.kt
@@ -3,7 +3,6 @@ package expo.modules.mpvplayer
 import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
-import android.view.Gravity
 import android.view.SurfaceHolder
 import android.view.SurfaceView
 import android.widget.FrameLayout
@@ -22,10 +21,14 @@ class MpvPlayerView(context: Context, appContext: AppContext) :
 
   private val core = MpvCore(context.applicationContext)
   private val surfaceView = SurfaceView(context)
-  // The SurfaceView lives inside an aspect-ratio container (ExoPlayer's AspectRatioFrameLayout pattern) so
-  // aspect is applied ONCE per video, declaratively, in the layout pass — instead of imperatively mutating
-  // the surface's layoutParams on every event (which thrashed the surface + raced the HDR switch).
-  private val videoContainer = AspectRatioFrameLayout(context)
+  // A full-size container that measures + lays out + CENTERS the SurfaceView itself. We do NOT rely on the
+  // parent centering a self-shrunk container (React Native lays a native view's children out top-left and
+  // ignores Android layout_gravity → the old AspectRatioFrameLayout landed off-center: bars only on the right/
+  // bottom), and we do NOT rely on requestLayout() (it doesn't propagate inside an RN view subtree, so an
+  // aspect change stuck until a full remount). The container fills; only the SurfaceView is letterboxed, and
+  // ONLY on the HDR path (see applyAspect). SDR/mini → the SurfaceView fills = the pre-0.13.19 full surface,
+  // so mpv's gpu-next handles the letterbox exactly as it always did.
+  private val videoContainer = VideoContainer(context)
 
   private var didSetup = false
   private var pendingSource: String? = null
@@ -48,9 +51,8 @@ class MpvPlayerView(context: Context, appContext: AppContext) :
   // option fixes it — mpv-android#486), so a full-screen surface stretches non-16:9 content (e.g. 3840x2076
   // cinema → +4% taller). The container letterboxes it. The real display size arrives via `mpvVideoSize` (the
   // core watches mpv's dwidth/dheight as they settle — the first read can be a placeholder like 960x540 before
-  // the frame decodes). That updates videoW/videoH and re-letterboxes. We do NOT force relayouts or run a
-  // global-layout listener: that churned the surface and caused HDR reconfig flicker; a real size change
-  // already triggers a relayout via setAspectRatio.
+  // the frame decodes). That updates videoW/videoH and re-letterboxes (applyAspect → videoContainer.targetRatio,
+  // which centers the SurfaceView). SDR leaves the surface full-screen so mpv's gpu-next letterboxes it itself.
   private var videoW = 0
   private var videoH = 0
   private var contentFit = "contain"
@@ -73,18 +75,13 @@ class MpvPlayerView(context: Context, appContext: AppContext) :
 
   init {
     setBackgroundColor(Color.BLACK)
-    // SurfaceView fills the aspect container; the container is centered in this (black) view, so any
-    // letterbox/pillarbox bars are just this view's background showing through.
-    surfaceView.layoutParams = FrameLayout.LayoutParams(
-      FrameLayout.LayoutParams.MATCH_PARENT,
-      FrameLayout.LayoutParams.MATCH_PARENT,
-    )
+    // The container fills this (black) view and lays the SurfaceView out itself (centered, sized per
+    // targetRatio). Any letterbox/pillarbox bars are the black background showing through.
     surfaceView.holder.addCallback(this)
     videoContainer.addView(surfaceView)
     videoContainer.layoutParams = FrameLayout.LayoutParams(
       FrameLayout.LayoutParams.MATCH_PARENT,
       FrameLayout.LayoutParams.MATCH_PARENT,
-      Gravity.CENTER,
     )
     addView(videoContainer)
     core.delegate = this
@@ -97,6 +94,7 @@ class MpvPlayerView(context: Context, appContext: AppContext) :
   }
 
   override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
+    android.util.Log.i("MpvCore", "surfaceChanged ${width}x${height} (view=${this.width}x${this.height})")
     core.setSurfaceSize(width, height)
   }
 
@@ -111,14 +109,15 @@ class MpvPlayerView(context: Context, appContext: AppContext) :
    * On SDR, mpv's own renderer (gpu-next) letterboxes correctly inside the full-screen surface via
    * keepaspect/panscan, so we leave the container FILLING (ratio 0) and let mpv handle it — no view-layer
    * constraint, and no surface-resize churn from resizing the SurfaceView off full-screen. "cover"/"fill" (or
-   * unknown dims) → 0 = fill even on HDR. `setAspectRatio` only re-lays-out when the ratio actually changes
-   * (once per video), so no per-event churn.
+   * unknown dims) → 0 = fill even on HDR. `VideoContainer.targetRatio` only re-lays-out when the ratio actually
+   * changes (once per video), so no per-event churn.
    */
   private fun applyAspect() {
     val hdr = pendingDynamicRange == "hdr"
     val forceFill = contentFit == "cover" || contentFit == "fill"
     val ratio = if (hdr && !forceFill && videoW > 0 && videoH > 0) videoW.toFloat() / videoH.toFloat() else 0f
-    videoContainer.setAspectRatio(ratio)
+    android.util.Log.i("MpvCore", "applyAspect ratio=$ratio (video=${videoW}x${videoH} fit=$contentFit hdr=$hdr)")
+    videoContainer.targetRatio = ratio
   }
 
   // MARK: props
@@ -276,43 +275,71 @@ class MpvPlayerView(context: Context, appContext: AppContext) :
 }
 
 /**
- * A FrameLayout that constrains itself to a target video aspect ratio (RESIZE_MODE_FIT), so a child
- * SurfaceView filling it is letterboxed rather than stretched. This is the standard ExoPlayer
- * `AspectRatioFrameLayout` technique — aspect is applied declaratively in the measure pass, and
- * `setAspectRatio` only requests a relayout when the ratio actually changes, so there's no per-event
- * surface churn. `ratio <= 0` = fill (no constraint). Centered by its parent's gravity.
+ * A full-size FrameLayout that sizes + CENTERS its single child (the SurfaceView) itself.
+ *
+ * `targetRatio == 0` → the child fills the container (the pre-0.13.19 full-screen surface: mpv's own
+ * gpu-next renderer letterboxes SDR correctly inside it). `targetRatio > 0` → the child is letterboxed to
+ * that aspect and centered — used ONLY for the HDR VO `mediacodec_embed`, which renders the MediaCodec
+ * surface directly and ignores mpv's keepaspect/panscan (mpv-android#486), so it must be shaped at the view
+ * layer.
+ *
+ * Two things this deliberately does NOT rely on, because both fail inside a React Native native view:
+ *  - **Parent gravity.** We center the child explicitly (child.layout), not via layout_gravity — RN lays a
+ *    native view's children out itself and doesn't honor Android gravity.
+ *  - **requestLayout() propagation.** RN's UIManager owns the layout pass and does not re-lay-out a native
+ *    ViewGroup's children when it calls requestLayout(). The documented workaround (Shopify) is to override
+ *    requestLayout() and post a runnable that measures + lays out ourselves — which drives our onLayout, so
+ *    an aspect change (or a reset to fill) takes effect immediately instead of sticking until a full remount.
  */
-private class AspectRatioFrameLayout(context: Context) : FrameLayout(context) {
-  private var aspectRatio = 0f
-
-  fun setAspectRatio(ratio: Float) {
-    if (aspectRatio != ratio) {
-      aspectRatio = ratio
-      requestLayout()
+private class VideoContainer(context: Context) : FrameLayout(context) {
+  // 0 = child fills; else the child is letterboxed to this aspect and centered.
+  var targetRatio = 0f
+    set(value) {
+      if (field != value) {
+        field = value
+        requestLayout()
+      }
     }
+
+  private val measureAndLayout = Runnable {
+    measure(
+      MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+      MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY),
+    )
+    layout(left, top, right, bottom)
   }
 
-  override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-    super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-    if (aspectRatio <= 0f) return
-    val w = measuredWidth
-    val h = measuredHeight
-    if (w == 0 || h == 0) return
-    val viewAspect = w.toFloat() / h.toFloat()
-    // Within tolerance of the panel aspect → fill (avoids a sub-pixel 1px letterbox on near-16:9 content).
-    if (Math.abs(aspectRatio / viewAspect - 1f) <= 0.01f) return
-    var nw = w
-    var nh = h
-    if (viewAspect < aspectRatio) {
-      // Video is wider than the view → limit height (bars top/bottom).
-      nh = Math.round(w / aspectRatio)
-    } else {
-      // Video is taller than the view → limit width (bars left/right).
-      nw = Math.round(h * aspectRatio)
+  override fun requestLayout() {
+    super.requestLayout()
+    // RN won't run our layout pass on its own — post one (the canonical RN Android workaround).
+    post(measureAndLayout)
+  }
+
+  override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
+    val cw = r - l
+    val ch = b - t
+    val child = getChildAt(0) ?: return
+    if (cw <= 0 || ch <= 0) return
+    var w = cw
+    var h = ch
+    if (targetRatio > 0f) {
+      val viewAspect = cw.toFloat() / ch.toFloat()
+      // Within tolerance of the container aspect → fill (avoids a sub-pixel 1px bar on near-16:9 content).
+      if (Math.abs(targetRatio / viewAspect - 1f) > 0.01f) {
+        if (viewAspect < targetRatio) {
+          h = Math.round(cw / targetRatio) // video wider than container → bars top/bottom
+        } else {
+          w = Math.round(ch * targetRatio) // video taller than container → bars left/right
+        }
+      }
     }
-    super.onMeasure(
-      MeasureSpec.makeMeasureSpec(nw, MeasureSpec.EXACTLY),
-      MeasureSpec.makeMeasureSpec(nh, MeasureSpec.EXACTLY),
+    val left = (cw - w) / 2
+    val top = (ch - h) / 2
+    child.measure(
+      MeasureSpec.makeMeasureSpec(w, MeasureSpec.EXACTLY),
+      MeasureSpec.makeMeasureSpec(h, MeasureSpec.EXACTLY),
     )
+    child.layout(left, top, left + w, top + h)
+    android.util.Log.i("MpvCore", "layout surface ${w}x${h} at ($left,$top) container=${cw}x${ch} ratio=$targetRatio")
   }
 }

--- a/packages/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvPlayerView.kt
+++ b/packages/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvPlayerView.kt
@@ -105,13 +105,20 @@ class MpvPlayerView(context: Context, appContext: AppContext) :
   }
 
   /**
-   * Feed the video's display aspect to the container. "cover"/"fill" (or unknown dims) → 0 = fill the whole
-   * view (no letterbox); "contain"/default → the content aspect, so the container centers + letterboxes it.
-   * `setAspectRatio` only re-lays-out when the ratio actually changes (once per video), so no per-event churn.
+   * Feed the video's display aspect to the container — but ONLY on the HDR path. The HDR VO
+   * `mediacodec_embed` renders the MediaCodec surface directly and ignores mpv's keepaspect/panscan
+   * (mpv-android#486), so a full-screen surface stretches non-16:9 content → we letterbox at the view layer.
+   * On SDR, mpv's own renderer (gpu-next) letterboxes correctly inside the full-screen surface via
+   * keepaspect/panscan, so we leave the container FILLING (ratio 0) and let mpv handle it — no view-layer
+   * constraint, and no surface-resize churn from resizing the SurfaceView off full-screen. "cover"/"fill" (or
+   * unknown dims) → 0 = fill even on HDR. `setAspectRatio` only re-lays-out when the ratio actually changes
+   * (once per video), so no per-event churn.
    */
   private fun applyAspect() {
-    val fill = contentFit == "cover" || contentFit == "fill" || videoW <= 0 || videoH <= 0
-    videoContainer.setAspectRatio(if (fill) 0f else videoW.toFloat() / videoH.toFloat())
+    val hdr = pendingDynamicRange == "hdr"
+    val forceFill = contentFit == "cover" || contentFit == "fill"
+    val ratio = if (hdr && !forceFill && videoW > 0 && videoH > 0) videoW.toFloat() / videoH.toFloat() else 0f
+    videoContainer.setAspectRatio(ratio)
   }
 
   // MARK: props

--- a/packages/mpv-player/ios/MpvPlayerModule.swift
+++ b/packages/mpv-player/ios/MpvPlayerModule.swift
@@ -63,6 +63,10 @@ public class MpvPlayerModule: Module {
       // triggers the coalesced load. (DVR seeks go through the imperative `seek` below, not startTime.)
       Prop("startTime") { (view: MpvPlayerView, t: Double) in view.setPendingStartTime(t) }
       Prop("mode") { (view: MpvPlayerView, mode: String) in view.setPendingMode(mode) }
+      // Accepted for the 1:1 cross-platform contract; iOS/tvOS handle HDR via their own display-criteria path,
+      // so these are inert here (only Android's up-front VO selection acts on them).
+      Prop("dynamicRange") { (view: MpvPlayerView, range: String?) in view.setPendingHdr(range) }
+      Prop("supportsHdr") { (view: MpvPlayerView, supported: Bool) in view.setSupportsHdr(supported) }
       Prop("source") { (view: MpvPlayerView, source: String?) in view.setPendingSource(source) }
       Prop("paused") { (view: MpvPlayerView, paused: Bool) in view.setPaused(paused) }
       Prop("muted") { (view: MpvPlayerView, muted: Bool) in view.setMuted(muted) }

--- a/packages/mpv-player/ios/MpvPlayerView.swift
+++ b/packages/mpv-player/ios/MpvPlayerView.swift
@@ -22,6 +22,11 @@ final class MpvPlayerView: ExpoView, MpvCoreDelegate {
   // load (bumper bed) must NOT touch the HDMI dynamic-range mode, or every bumper would bounce an HDR program
   // HDR→SDR→HDR (a black re-sync). We leave the last program's criteria in place across the bumper.
   private var currentMode: String = "video"
+  // Accepted from JS for a 1:1 cross-platform contract but NOT consulted on Apple: tvOS already drives HDR via
+  // its own display-criteria path (set on first frame), so the Android up-front-VO flags are inert here.
+  // Stored only so the props exist. See .plans/android-hdr-vo-predetect.md §2a.
+  private var pendingDynamicRange: String?
+  private var supportsHdr = false
   private var lastLoadedSource: String?
   private var applyScheduled = false
   private var lastWidth: Int = 0
@@ -75,6 +80,9 @@ final class MpvPlayerView: ExpoView, MpvCoreDelegate {
   }
   func setPendingStartTime(_ t: Double) { pendingStartTime = t }
   func setPendingMode(_ mode: String) { pendingMode = (mode == "audio") ? "audio" : "video" }
+  // Accepted for the 1:1 JS contract; iOS/tvOS handle HDR via display criteria, so these stay inert here.
+  func setPendingHdr(_ dynamicRange: String?) { pendingDynamicRange = dynamicRange }
+  func setSupportsHdr(_ supported: Bool) { supportsHdr = supported }
 
   func setContentFit(_ fit: String) {
     switch fit {

--- a/packages/mpv-player/src/MpvPlayer.types.ts
+++ b/packages/mpv-player/src/MpvPlayer.types.ts
@@ -63,6 +63,20 @@ export interface MpvPlayerViewProps extends ViewProps {
    * `.plans/mpv-hybrid-core.md`.
    */
   mode?: "video" | "audio";
+  /**
+   * The current program's dynamic range, from the server's `guide.hdr` (`"hdr"` when HDR10/Dolby Vision/HLG,
+   * `"sdr"` otherwise). Set alongside `source`. **Android** uses it to pick the mpv video output UP FRONT at
+   * load (`mediacodec_embed` for HDR passthrough vs `gpu-next`/`gpu` for SDR) — no first-frame detection, no
+   * re-open. Omit it (or leave it unset) for bumper/audio-only loads so the VO is left untouched. **iOS/tvOS**
+   * accept it but ignore it (they drive HDR via their own display-criteria path). See
+   * `.plans/android-hdr-vo-predetect.md`.
+   */
+  dynamicRange?: "hdr" | "sdr";
+  /**
+   * Whether the panel is HDR-capable (from the client's display probe). Plumbed for a future display-gated VO
+   * decision (HDR content on an SDR panel → tone-map on `gpu-next`); **not yet consulted** on any platform.
+   */
+  supportsHdr?: boolean;
   /** `true` = paused. */
   paused?: boolean;
   muted?: boolean;


### PR DESCRIPTION
Replaces the Android first-frame HDR detection + `loadfile replace` re-open with **up-front VO selection** from the program's known dynamic range, and fixes the view-layer letterbox that the aspect work had regressed. Verified on a Fire TV Stick 4K Max.

## Server (v0.13.20)
- `resolveMedia` returns `hdr` on `GET /api/v1/channels/:id/media` (read from `MediaItem.guide.hdr`), on the same `guide` read that already backed `dovi`. No new column/endpoint/query.

## Android client (v0.13.21–0.13.23)
- **Up-front VO (v0.13.21):** the mpv core picks `mediacodec_embed` (+ `hwdec=mediacodec`) for HDR vs `gpu-next`/`gpu` for SDR **at the load boundary, before the `loadfile`**, from the new `dynamicRange` flag. `maybeSwitchHdr` (first-frame probe + re-open) is deleted. This removes the two device-confirmed regressions: seek-back across a program boundary restarting from 0, and the mid-stream surface reconfigure flicker / HDR↔Dolby-Vision badge flip. Bumper/audio loads carry no flag → the VO is left untouched (matches iOS; no pointless HDR↔SDR churn).
- **SDR letterbox gating (v0.13.22):** the view-layer letterbox applies only on the HDR (`mediacodec_embed`) path; SDR leaves the surface full-screen so mpv's own gpu-next letterboxes it, exactly as before 0.13.19.
- **Surface sizing fix (v0.13.23):** the player sizes and centers the SurfaceView itself — overriding `requestLayout()` to post a manual `measure`/`layout` (the documented RN Android workaround, since RN's UIManager doesn't re-lay-out a native ViewGroup's children) and centering explicitly rather than relying on Android `layout_gravity` (which RN ignores). Fixes HDR video being stretched / corner-pinned / stuck across programs until a full close+reopen.
- Event-driven `dwidth`/`dheight` size observers drive the letterbox, deduped so they never churn the surface. Added `applyAspect` / `surfaceChanged` / `layout surface` logcat lines for on-device visibility.

## JS ↔ native contract
- New declarative `dynamicRange` (`"hdr"`/`"sdr"`) prop set alongside `source`, plus a staged `supportsHdr` prop (panel HDR capability, plumbed for a future display-gated decision, not yet consulted). Both exposed on iOS and Android 1:1; **iOS/tvOS accept them but are unaffected** (they drive HDR via their own display-criteria path).

## Verified on device (Fire TV Stick 4K Max)
- HDR direct-play letterboxes correctly and centered; seek-back across a bumper into HDR does not restart from 0; no reconfigure flicker / badge flip; SDR unchanged; HDR↔SDR switching is stable.

## Known, deferred
- A small constant audio lead on the HDR (`mediacodec_embed`) path — a known mpv-android trait (mpv-android#414); an HDR-only `audio-delay` correction can be added and tuned later.