### PR TITLE
feat(tv-tauri): Linux desktop video via mpv render API (draft)

### DIFF
--- a/.github/workflows/libmpv-linux.yml
+++ b/.github/workflows/libmpv-linux.yml
@@ -43,7 +43,7 @@ jobs:
             build-essential git curl python3 meson ninja-build pkg-config patchelf nasm \
             libfreetype-dev libfribidi-dev liblcms2-dev libluajit-5.1-dev \
             libass-dev libopus-dev librubberband-dev \
-            zlib1g-dev libbz2-dev liblzma-dev \
+            zlib1g-dev libbz2-dev liblzma-dev libssl-dev \
             libpipewire-0.3-dev libpulse-dev \
             libxss-dev libxpresent-dev \
             libwayland-dev wayland-protocols libxkbcommon-dev \
@@ -94,7 +94,7 @@ jobs:
             build-essential git curl python3 meson ninja-build pkg-config patchelf nasm \
             libfreetype-dev libfribidi-dev liblcms2-dev libluajit-5.1-dev \
             libass-dev libopus-dev librubberband-dev \
-            zlib1g-dev libbz2-dev liblzma-dev \
+            zlib1g-dev libbz2-dev liblzma-dev libssl-dev \
             libpipewire-0.3-dev libpulse-dev \
             libxss-dev libxpresent-dev \
             libwayland-dev wayland-protocols libxkbcommon-dev \

--- a/.github/workflows/tv-tauri-release.yml
+++ b/.github/workflows/tv-tauri-release.yml
@@ -425,6 +425,13 @@ jobs:
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
+          # GitHub runners have no FUSE, and linuxdeploy (+ its appimage plugin) are themselves AppImages —
+          # extract-and-run instead of mounting.
+          APPIMAGE_EXTRACT_AND_RUN: "1"
+          NO_STRIP: "true"
+          # libmpv.so.2 is vendored (linked via build.rs, no rpath) — put it on the lib path so linuxdeploy
+          # can resolve + bundle it into the AppImage.
+          LD_LIBRARY_PATH: ${{ github.workspace }}/apps/tv-tauri/src-tauri/vendor/libmpv/linux-x64/lib
         run: pnpm tauri build --bundles appimage
 
       - name: Stage AppImage (Linux)

--- a/.github/workflows/tv-tauri-release.yml
+++ b/.github/workflows/tv-tauri-release.yml
@@ -448,6 +448,8 @@ jobs:
           DEPLOY_GTK_VERSION: "3"
           NO_APPSTREAM: "1"
           LDAI_NO_APPSTREAM: "1"
+          # Surface the gtk plugin's output (Installing AppRun hook / excludes) so we can confirm it ran.
+          TAURI_BUNDLER_LOG_LEVEL: "debug"
           # libmpv.so.2 is vendored (linked via build.rs, no rpath) — put it on the lib path so linuxdeploy
           # can resolve + bundle it into the AppImage.
           LD_LIBRARY_PATH: ${{ github.workspace }}/apps/tv-tauri/src-tauri/vendor/libmpv/linux-x64/lib

--- a/.github/workflows/tv-tauri-release.yml
+++ b/.github/workflows/tv-tauri-release.yml
@@ -6,7 +6,8 @@ name: TV Desktop (tv-tauri) Build & Release
 #
 # STATUS: WINDOWS (signed NSIS + updater) and macOS (Apple Silicon + Intel, .app/.dmg) are real builds.
 # macOS is UNSIGNED for now — signing/notarization + a merged latest.json are the finalize pass (Phase
-# 8C). LINUX stays a NO-OP until its X11/wayland embed lands. See .plans/tv-tauri.md Phase 8.
+# 8C). LINUX is a DRAFT AppImage build (render API into a GTK GLArea) — a downloadable workflow artifact
+# for on-device testing, not yet wired into latest.json/updater. See .plans/tv-tauri-linux-render.md.
 #
 # The big libmpv runtime DLLs are NOT committed — this fetches them from the `libmpv-latest` release
 # (built by libmpv-windows.yml) into vendor/. The tiny MSVC import lib (windows-x64/lib/mpv.lib) IS
@@ -58,10 +59,14 @@ jobs:
             updaterarch: x86_64
             target: x86_64-apple-darwin
             supported: true
-          # NO-OP until the Linux X11/wayland embed lands.
+          # Linux x64 — render API (vo=libmpv into a GTK GLArea behind the transparent WebKitGTK webview),
+          # bundled as an AppImage (runs on any distro incl. Arch/Omarchy). `target` empty → native x86_64.
           - os: ubuntu-24.04
             arch: x64
-            supported: false
+            libmpv: linux-x64
+            updaterarch: x86_64
+            target: ""
+            supported: true
     runs-on: ${{ matrix.os }}
 
     env:
@@ -78,6 +83,17 @@ jobs:
         if: ${{ !matrix.supported }}
         shell: bash
         run: echo "tv-tauri ${{ matrix.os }} is a no-op until its mpv render-attach lands (Phase 6). Skipping."
+
+      # Linux (Tauri v2 on ubuntu-24.04): WebKitGTK 4.1 + GTK3 dev, plus GL/EGL/epoxy for the GLArea render
+      # context and AppImage tooling deps. libmpv itself comes from the release tarball below.
+      - name: Install Linux build deps
+        if: matrix.supported && runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev patchelf \
+            libepoxy-dev libegl1-mesa-dev libgl1-mesa-dev \
+            libappindicator3-dev file
 
       - uses: pnpm/action-setup@v4
         if: matrix.supported
@@ -127,6 +143,9 @@ jobs:
           if [ -n "$BIN_SRC" ]; then rm -rf "$DEST/bin"; cp -r "$BIN_SRC" "$DEST/bin"; fi
           if [ "$RUNNER_OS" = "Windows" ]; then
             ls "$DEST/lib/mpv.lib" >/dev/null || { echo "mpv.lib missing (re-run libmpv-windows.yml)"; ls "$DEST/lib"; exit 1; }
+          elif [ "$RUNNER_OS" = "Linux" ]; then
+            # Linux: the linker wants `libmpv.so`; symlink to the soname (`libmpv.so.2`).
+            ( cd "$DEST/lib" && { [ -e libmpv.so ] || ln -s libmpv.so.* libmpv.so; } )
           else
             # macOS: the linker wants `libmpv.dylib`; symlink to the soname (`libmpv.2.dylib`).
             ( cd "$DEST/lib" && { [ -e libmpv.dylib ] || ln -s libmpv.*.dylib libmpv.dylib; } )
@@ -394,6 +413,30 @@ jobs:
               {key:'darwin-${ARCH}', signature:process.env.SIG, url:process.env.URL}));
           "
           cat "artifacts/frag-darwin-${ARCH}.json"; echo
+          ls -la "$OUT"
+
+      # ── Linux (AppImage) — DRAFT (render API into a GTK GLArea; needs on-device validation). Build the
+      # AppImage and stage it for the upload step below. No updater fragment yet (unvalidated), so it never
+      # touches latest.json; the AppImage is just a downloadable workflow artifact to test on Arch/Omarchy.
+      - name: Build (Tauri AppImage) — Linux
+        if: matrix.supported && runner.os == 'Linux'
+        working-directory: apps/tv-tauri
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
+        run: pnpm tauri build --bundles appimage
+
+      - name: Stage AppImage (Linux)
+        if: matrix.supported && runner.os == 'Linux'
+        working-directory: apps/tv-tauri
+        shell: bash
+        run: |
+          set -euo pipefail
+          APPIMG="$(ls src-tauri/target/release/bundle/appimage/*.AppImage | head -1)"
+          VER="$(node -p "require('./package.json').version")"
+          OUT="artifacts"; mkdir -p "$OUT"
+          cp "$APPIMG" "$OUT/Airwave-Client_${VER}_x86_64.AppImage"
           ls -la "$OUT"
 
       - name: Upload build artifacts

--- a/.github/workflows/tv-tauri-release.yml
+++ b/.github/workflows/tv-tauri-release.yml
@@ -93,7 +93,9 @@ jobs:
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev patchelf \
             libepoxy-dev libegl1-mesa-dev libgl1-mesa-dev \
-            libappindicator3-dev file
+            libappindicator3-dev file \
+            libglib2.0-dev libglib2.0-bin libgdk-pixbuf-2.0-dev libgtk-3-bin \
+            libpango1.0-dev desktop-file-utils squashfs-tools
 
       - uses: pnpm/action-setup@v4
         if: matrix.supported
@@ -418,6 +420,19 @@ jobs:
       # ── Linux (AppImage) — DRAFT (render API into a GTK GLArea; needs on-device validation). Build the
       # AppImage and stage it for the upload step below. No updater fragment yet (unvalidated), so it never
       # touches latest.json; the AppImage is just a downloadable workflow artifact to test on Arch/Omarchy.
+      # soia's proven Linux discrepancy: bundle the AppImage via linuxdeploy-plugin-gtk so the host's
+      # graphics/Wayland/DRM/VA libs are EXCLUDED (used from the host) instead of shadowed by bundled copies.
+      # Bundled copies are what break WebKitGTK's EGL on real GPUs/virgl ("Could not create default EGL
+      # display: EGL_BAD_PARAMETER"). Tauri's linuxdeploy auto-runs the plugin when it's in ~/.cache/tauri.
+      - name: Prepare linuxdeploy GTK plugin (Linux)
+        if: matrix.supported && runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.cache/tauri"
+          cp apps/tv-tauri/scripts/linuxdeploy-plugin-gtk.sh "$HOME/.cache/tauri/linuxdeploy-plugin-gtk.sh"
+          chmod +x "$HOME/.cache/tauri/linuxdeploy-plugin-gtk.sh"
+
       - name: Build (Tauri AppImage) — Linux
         if: matrix.supported && runner.os == 'Linux'
         working-directory: apps/tv-tauri
@@ -429,6 +444,10 @@ jobs:
           # extract-and-run instead of mounting.
           APPIMAGE_EXTRACT_AND_RUN: "1"
           NO_STRIP: "true"
+          # linuxdeploy-plugin-gtk: GTK3 app; skip AppStream metadata generation (no metainfo shipped).
+          DEPLOY_GTK_VERSION: "3"
+          NO_APPSTREAM: "1"
+          LDAI_NO_APPSTREAM: "1"
           # libmpv.so.2 is vendored (linked via build.rs, no rpath) — put it on the lib path so linuxdeploy
           # can resolve + bundle it into the AppImage.
           LD_LIBRARY_PATH: ${{ github.workspace }}/apps/tv-tauri/src-tauri/vendor/libmpv/linux-x64/lib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to Airwave are documented here.
 
+## [0.13.39] - 2026-09-12
+
+Desktop (Linux) — give the bundled mpv a TLS backend so the capability diagnostic works.
+
+### Fixed
+- The Linux libmpv build now links OpenSSL (`--enable-openssl --enable-version3` in the FFmpeg build), giving
+  mpv an `https` TLS backend. Windows and macOS get native TLS automatically (SChannel / SecureTransport);
+  Linux had none, so the on-device capability diagnostic — which fetches its test clips from the Airwave
+  server over `https` — failed every probe and defaulted the device profile to all-transcode. Live channel
+  playback was never affected (LAN Plex connections are plain `http`). Requires the Linux libmpv runtime
+  rebuilt from the `libmpv-linux` workflow (x64 and arm64).
+
+## [0.13.38] - 2026-09-12
+
+TV (desktop / tv-tauri) — Linux support: the Airwave desktop client now builds, runs, and plays on Linux.
+
+### Added
+- Linux (Wayland) is now a supported tv-tauri target, packaged as an AppImage in CI. This brings the desktop
+  client to every desktop OS. Video renders through mpv's render API into a Wayland subsurface placed behind
+  the transparent webview (the same render-API approach as macOS; Windows keeps its native-handle embed),
+  wired through a per-OS three-way video attach.
+
+### Fixed
+- AppImage packaging bundles the app with `linuxdeploy-plugin-gtk`, with its library-exclude list pruned to
+  only the host's GPU / display / Wayland libraries (libEGL, libGL, libdrm, libva, libvulkan, libwayland-*).
+  Bundling those made them shadow the host driver's own copies, which stopped WebKitGTK from creating an EGL
+  display and left a blank window on real GPUs and in VMs. Non-graphics libraries stay bundled so the
+  AppImage still runs on minimal distros that lack them (e.g. libselinux on Arch).
+- `setlocale(LC_NUMERIC, "C")` is now set before `mpv_create()` on Linux, which mpv requires or it refuses to
+  initialize.
+
 ## [0.13.37] - 2026-09-12
 
 TV (desktop / tv-tauri) — click the video to play/pause.

--- a/apps/desktop-setup/package.json
+++ b/apps/desktop-setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airwave/desktop-setup",
-  "version": "0.13.37",
+  "version": "0.13.39",
   "private": true,
   "type": "module",
   "description": "Airwave Desktop first-run onboarding / settings UI — a small Vite + React app built with @airwave/ui (shadcn + oklch theme), rendered in the desktop app's native webview and driven by the supervisor's /config, /save, /status endpoints.",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.13.37",
+  "version": "0.13.39",
   "private": true,
   "type": "module",
   "description": "Airwave Desktop — an Electrobun tray-only supervisor that runs embedded Postgres + the Airwave server + admin + tv-web on local ports, next to Plex. The browser is the UI. See .plans/desktop-server.md.",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.13.37",
+  "version": "0.13.39",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "site",
-  "version": "0.13.37",
+  "version": "0.13.39",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/tv-native/app.json
+++ b/apps/tv-native/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Airwave",
     "slug": "airwave",
-    "version": "0.13.37",
+    "version": "0.13.39",
     "scheme": "airwave",
     "orientation": "landscape",
     "userInterfaceStyle": "dark",

--- a/apps/tv-native/package.json
+++ b/apps/tv-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-native",
-  "version": "0.13.37",
+  "version": "0.13.39",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {

--- a/apps/tv-roku/manifest
+++ b/apps/tv-roku/manifest
@@ -3,7 +3,7 @@ title=Airwave
 # Version — kept in lockstep with the other apps/* (see /version-bump). Mirrors package.json 0.12.0.
 major_version=0
 minor_version=13
-build_version=37
+build_version=39
 
 # Icons = branded logo mark on the radial gradient (home-screen tile). Splash = a FLAT #060a14 fill (Roku
 # requires a splash image, but ours hands off seamlessly to the in-app animated LogoLockup, which fades the

--- a/apps/tv-roku/package.json
+++ b/apps/tv-roku/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-roku",
-  "version": "0.13.37",
+  "version": "0.13.39",
   "private": true,
   "description": "Airwave Roku client (BrighterScript + SceneGraph). A direct port of tv-web/tv-native to Roku — strict visual + functional parity, its own separately-maintained codebase.",
   "scripts": {

--- a/apps/tv-tauri/package.json
+++ b/apps/tv-tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-tauri",
-  "version": "0.13.37",
+  "version": "0.13.39",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/tv-tauri/scripts/linuxdeploy-plugin-gtk.sh
+++ b/apps/tv-tauri/scripts/linuxdeploy-plugin-gtk.sh
@@ -1,0 +1,410 @@
+#! /usr/bin/env bash
+
+# GTK3 environment variables: https://developer.gnome.org/gtk3/stable/gtk-running.html
+# GTK4 environment variables: https://developer.gnome.org/gtk4/stable/gtk-running.html
+
+# abort on all errors
+set -e
+
+if [ "$DEBUG" != "" ]; then
+    set -x
+    verbose="--verbose"
+fi
+
+script=$(readlink -f "$0")
+
+show_usage() {
+    echo "Usage: $script --appdir <path to AppDir>"
+    echo
+    echo "Bundles resources for applications that use GTK into an AppDir"
+    echo
+    echo "Required variables:"
+    echo "  LINUXDEPLOY=\".../linuxdeploy\" path to linuxdeploy (e.g., AppImage); set automatically when plugin is run directly by linuxdeploy"
+    #echo
+    #echo "Optional variables:"
+    #echo "  DEPLOY_GTK_VERSION (major version of GTK to deploy, e.g. '2', '3' or '4'; auto-detect by default)"
+}
+
+variable_is_true() {
+    local var="$1"
+
+    if [ -n "$var" ] && { [ "$var" == "true" ] || [ "$var" -gt 0 ]; } 2> /dev/null; then
+        return 0 # true
+    else
+        return 1 # false
+    fi
+}
+
+get_pkgconf_variable() {
+    local variable="$1"
+    local library="$2"
+    local default_path="$3"
+
+    path="$("$PKG_CONFIG" --variable="$variable" "$library")"
+    if [ -n "$path" ]; then
+        echo "$path"
+    elif [ -n "$default_path" ]; then
+        echo "$default_path"
+    else
+        echo "$0: there is no '$variable' variable for '$library' library." > /dev/stderr
+        echo "Please check the '$library.pc' file is present in \$PKG_CONFIG_PATH (you may need to install the appropriate -dev/-devel package)." > /dev/stderr
+        exit 1
+    fi
+}
+
+copy_tree() {
+    local src=("${@:1:$#-1}")
+    local dst="${*:$#}"
+
+    for elem in "${src[@]}"; do
+        mkdir -p "${dst::-1}$elem"
+        cp "$elem" --archive --parents --target-directory="$dst" $verbose
+    done
+}
+
+search_tool() {
+    local tool="$1"
+    local directory="$2"
+
+    if command -v "$tool"; then
+        return 0
+    fi
+
+    PATH_ARRAY=(
+        "/usr/lib/$(uname -m)-linux-gnu/$directory/$tool"
+        "/usr/lib/$directory/$tool"
+        "/usr/bin/$tool"
+        "/usr/bin/$tool-64"
+        "/usr/bin/$tool-32"
+    )
+
+    for path in "${PATH_ARRAY[@]}"; do
+        if [ -x "$path" ]; then
+            echo "$path"
+            return 0
+        fi
+    done
+}
+
+#DEPLOY_GTK_VERSION="${DEPLOY_GTK_VERSION:-0}" # When not set by user, this variable use the integer '0' as a sentinel value
+DEPLOY_GTK_VERSION=3 # Force GTK3 for tauri apps
+APPDIR=
+
+while [ "$1" != "" ]; do
+    case "$1" in
+        --plugin-api-version)
+            echo "0"
+            exit 0
+            ;;
+        --appdir)
+            APPDIR="$2"
+            shift
+            shift
+            ;;
+        --help)
+            show_usage
+            exit 0
+            ;;
+        *)
+            echo "Invalid argument: $1"
+            echo
+            show_usage
+            exit 1
+            ;;
+    esac
+done
+
+if [ "$APPDIR" == "" ]; then
+    show_usage
+    exit 1
+fi
+
+mkdir -p "$APPDIR"
+# make lib64 writable again.
+chmod +w "$APPDIR"/usr/lib64 || true
+
+if command -v pkgconf > /dev/null; then
+    PKG_CONFIG="pkgconf"
+elif command -v pkg-config > /dev/null; then
+    PKG_CONFIG="pkg-config"
+else
+    echo "$0: pkg-config/pkgconf not found in PATH, aborting"
+    exit 1
+fi
+
+if ! command -v find &>/dev/null && ! type find &>/dev/null; then
+    echo -e "$0: find not found.\nInstall findutils then re-run the plugin."
+    exit 1
+fi
+
+if [ -z "$LINUXDEPLOY" ]; then
+    echo -e "$0: LINUXDEPLOY environment variable is not set.\nDownload a suitable linuxdeploy AppImage, set the environment variable and re-run the plugin."
+    exit 1
+fi
+
+gtk_versions=0 # Count major versions of GTK when auto-detect GTK version
+if [ "$DEPLOY_GTK_VERSION" -eq 0 ]; then
+    echo "Determining which GTK version to deploy"
+    while IFS= read -r -d '' file; do
+        if [ "$DEPLOY_GTK_VERSION" -ne 2 ] && ldd "$file" | grep -q "libgtk-x11-2.0.so"; then
+            DEPLOY_GTK_VERSION=2
+            gtk_versions="$((gtk_versions+1))"
+        fi
+        if [ "$DEPLOY_GTK_VERSION" -ne 3 ] && ldd "$file" | grep -q "libgtk-3.so"; then
+            DEPLOY_GTK_VERSION=3
+            gtk_versions="$((gtk_versions+1))"
+        fi
+        if [ "$DEPLOY_GTK_VERSION" -ne 4 ] && ldd "$file" | grep -q "libgtk-4.so"; then
+            DEPLOY_GTK_VERSION=4
+            gtk_versions="$((gtk_versions+1))"
+        fi
+    done < <(find "$APPDIR/usr/bin" -executable -type f -print0)
+fi
+
+if [ "$gtk_versions" -gt 1 ]; then
+    echo "$0: can not deploy multiple GTK versions at the same time."
+    echo "Please set DEPLOY_GTK_VERSION to {2, 3, 4}."
+    exit 1
+elif [ "$DEPLOY_GTK_VERSION" -eq 0 ]; then
+    echo "$0: failed to auto-detect GTK version."
+    echo "Please set DEPLOY_GTK_VERSION to {2, 3, 4}."
+    exit 1
+fi
+
+echo "Installing AppRun hook"
+HOOKSDIR="$APPDIR/apprun-hooks"
+HOOKFILE="$HOOKSDIR/linuxdeploy-plugin-gtk.sh"
+mkdir -p "$HOOKSDIR"
+cat > "$HOOKFILE" <<\EOF
+#! /usr/bin/env bash
+
+gsettings get org.gnome.desktop.interface gtk-theme 2> /dev/null | grep -qi "dark" && GTK_THEME_VARIANT="dark" || GTK_THEME_VARIANT="light"
+APPIMAGE_GTK_THEME="${APPIMAGE_GTK_THEME:-"Adwaita:$GTK_THEME_VARIANT"}" # Allow user to override theme (discouraged)
+
+export APPDIR="${APPDIR:-"$(dirname "$(realpath "$0")")"}" # Workaround to run extracted AppImage
+export GTK_DATA_PREFIX="$APPDIR"
+export GTK_THEME="$APPIMAGE_GTK_THEME" # Custom themes are broken
+export GDK_BACKEND=wayland
+export XDG_DATA_DIRS="$APPDIR/usr/share:/usr/share:$XDG_DATA_DIRS" # g_get_system_data_dirs() from GLib
+EOF
+
+echo "Installing GLib schemas"
+# Note: schemasdir is undefined on Ubuntu 16.04
+glib_schemasdir="$(get_pkgconf_variable "schemasdir" "gio-2.0" "/usr/share/glib-2.0/schemas")"
+copy_tree "$glib_schemasdir" "$APPDIR/"
+glib-compile-schemas "$APPDIR/$glib_schemasdir"
+cat >> "$HOOKFILE" <<EOF
+export GSETTINGS_SCHEMA_DIR="\$APPDIR/$glib_schemasdir"
+EOF
+
+case "$DEPLOY_GTK_VERSION" in
+    2)
+        # https://github.com/linuxdeploy/linuxdeploy-plugin-gtk/pull/20#issuecomment-826354261
+        echo "WARNING: Gtk+2 applications are not fully supported by this plugin"
+        ;;
+    3)
+        echo "Installing GTK 3.0 modules"
+        gtk3_exec_prefix="$(get_pkgconf_variable "exec_prefix" "gtk+-3.0")"
+        gtk3_libdir="$(get_pkgconf_variable "libdir" "gtk+-3.0")/gtk-3.0"
+        #gtk3_path="$gtk3_libdir/modules" export GTK_PATH="\$APPDIR/$gtk3_path"
+        gtk3_immodulesdir="$gtk3_libdir/$(get_pkgconf_variable "gtk_binary_version" "gtk+-3.0")/immodules"
+        gtk3_printbackendsdir="$gtk3_libdir/$(get_pkgconf_variable "gtk_binary_version" "gtk+-3.0")/printbackends"
+        gtk3_immodules_cache_file="$(dirname "$gtk3_immodulesdir")/immodules.cache"
+        gtk3_immodules_query="$(search_tool "gtk-query-immodules-3.0" "libgtk-3-0")"
+        copy_tree "$gtk3_libdir" "$APPDIR/"
+        cat >> "$HOOKFILE" <<EOF
+export GTK_EXE_PREFIX="\$APPDIR/$gtk3_exec_prefix"
+export GTK_PATH="\$APPDIR/$gtk3_libdir:/usr/lib64/gtk-3.0:/usr/lib/x86_64-linux-gnu/gtk-3.0"
+export GTK_IM_MODULE_FILE="\$APPDIR/$gtk3_immodules_cache_file"
+
+EOF
+        if [ -x "$gtk3_immodules_query" ]; then
+            echo "Updating immodules cache in $APPDIR/$gtk3_immodules_cache_file"
+            "$gtk3_immodules_query" > "$APPDIR/$gtk3_immodules_cache_file"
+        else
+            echo "WARNING: gtk-query-immodules-3.0 not found"
+        fi
+        if [ ! -f "$APPDIR/$gtk3_immodules_cache_file" ]; then
+            echo "WARNING: immodules.cache file is missing"
+        fi
+        sed -i "s|$gtk3_libdir/3.0.0/immodules/||g" "$APPDIR/$gtk3_immodules_cache_file"
+        ;;
+    4)
+        echo "Installing GTK 4.0 modules"
+        gtk4_exec_prefix="$(get_pkgconf_variable "exec_prefix" "gtk4" "/usr")"
+        gtk4_libdir="$(get_pkgconf_variable "libdir" "gtk4")/gtk-4.0"
+        gtk4_path="$gtk4_libdir/modules"
+        copy_tree "$gtk4_libdir" "$APPDIR/"
+        cat >> "$HOOKFILE" <<EOF
+export GTK_EXE_PREFIX="\$APPDIR/$gtk4_exec_prefix"
+export GTK_PATH="\$APPDIR/$gtk4_path"
+EOF
+        ;;
+    *)
+        echo "$0: '$DEPLOY_GTK_VERSION' is not a valid GTK major version."
+        echo "Please set DEPLOY_GTK_VERSION to {2, 3, 4}."
+        exit 1
+esac
+
+echo "Installing GDK PixBufs"
+gdk_libdir="$(get_pkgconf_variable "libdir" "gdk-pixbuf-2.0")"
+gdk_pixbuf_binarydir="$(get_pkgconf_variable "gdk_pixbuf_binarydir" "gdk-pixbuf-2.0")"
+gdk_pixbuf_cache_file="$(get_pkgconf_variable "gdk_pixbuf_cache_file" "gdk-pixbuf-2.0")"
+gdk_pixbuf_moduledir="$(get_pkgconf_variable "gdk_pixbuf_moduledir" "gdk-pixbuf-2.0")"
+# Note: gdk_pixbuf_query_loaders variable is not defined on some systems
+gdk_pixbuf_query="$(search_tool "gdk-pixbuf-query-loaders" "gdk-pixbuf-2.0")"
+copy_tree "$gdk_pixbuf_binarydir" "$APPDIR/"
+cat >> "$HOOKFILE" <<EOF
+export GDK_PIXBUF_MODULE_FILE="\$APPDIR/$gdk_pixbuf_cache_file"
+EOF
+if [ -x "$gdk_pixbuf_query" ]; then
+    echo "Updating pixbuf cache in $APPDIR/$gdk_pixbuf_cache_file"
+    "$gdk_pixbuf_query" > "$APPDIR/$gdk_pixbuf_cache_file"
+else
+    echo "WARNING: gdk-pixbuf-query-loaders not found"
+fi
+if [ ! -f "$APPDIR/$gdk_pixbuf_cache_file" ]; then
+    echo "WARNING: loaders.cache file is missing"
+fi
+sed -i "s|$gdk_pixbuf_moduledir/||g" "$APPDIR/$gdk_pixbuf_cache_file"
+
+echo "Copying more libraries"
+gobject_libdir="$(get_pkgconf_variable "libdir" "gobject-2.0")"
+gio_libdir="$(get_pkgconf_variable "libdir" "gio-2.0")"
+librsvg_libdir="$(get_pkgconf_variable "libdir" "librsvg-2.0")"
+pango_libdir="$(get_pkgconf_variable "libdir" "pango")"
+pangocairo_libdir="$(get_pkgconf_variable "libdir" "pangocairo")"
+pangoft2_libdir="$(get_pkgconf_variable "libdir" "pangoft2")"
+FIND_ARRAY=(
+    "$gdk_libdir"     "libgdk_pixbuf-*.so*"
+    "$gobject_libdir" "libgobject-*.so*"
+    "$gio_libdir"     "libgio-*.so*"
+    "$librsvg_libdir" "librsvg-*.so*"
+    "$pango_libdir"      "libpango-*.so*"
+    "$pangocairo_libdir" "libpangocairo-*.so*"
+    "$pangoft2_libdir"   "libpangoft2-*.so*"
+)
+LIBRARIES=()
+for (( i=0; i<${#FIND_ARRAY[@]}; i+=2 )); do
+    directory=${FIND_ARRAY[i]}
+    library=${FIND_ARRAY[i+1]}
+    while IFS= read -r -d '' file; do
+        LIBRARIES+=( "--library=$file" )
+    done < <(find "$directory" \( -type l -o -type f \) -name "$library" -print0)
+done
+
+EXCLUDE_LIBRARIES=(
+    "libwayland-client.so.0"
+    "libwayland-cursor.so.0"
+    "libwayland-egl.so.1"
+    "libwayland-server.so.0"
+    "libudev.so.1"
+    "libsystemd.so.0"
+    "libcap.so.2"
+    "libdbus-1.so.3"
+    "libvulkan.so.1"
+    "libva.so.2"
+    "libva-drm.so.2"
+    "libva-x11.so.2"
+    "libvdpau.so.1"
+    "libdrm.so.2"
+    "libselinux.so.1"
+    "libapparmor.so.1"
+    "libseccomp.so.2"
+    "libacl.so.1"
+    "libkeyutils.so.1"
+    "libgudev-1.0.so.0"
+    "libmount.so.1"
+    "libblkid.so.1"
+    "libcups.so.2"
+    "libssl.so.3"
+    "libcrypto.so.3"
+    "libkrb5.so.3"
+    "libkrb5support.so.0"
+    "libgssapi_krb5.so.2"
+    "libk5crypto.so.3"
+    "libXau.so.6"
+    "libXcomposite.so.1"
+    "libXcursor.so.1"
+    "libXdamage.so.1"
+    "libXdmcp.so.6"
+    "libXext.so.6"
+    "libXfixes.so.3"
+    "libXinerama.so.1"
+    "libXi.so.6"
+    "libXpresent.so.1"
+    "libXrandr.so.2"
+    "libXrender.so.1"
+    "libXss.so.1"
+    "libXv.so.1"
+    "libxcb-render.so.0"
+    "libxcb-shape.so.0"
+    "libxcb-shm.so.0"
+    "libxcb-xfixes.so.0"
+    "libpulse.so.0"
+    "libpulsecommon-16.1.so"
+)
+EXCLUDE_ARGS=()
+for library in "${EXCLUDE_LIBRARIES[@]}"; do
+    EXCLUDE_ARGS+=( "--exclude-library=$library" )
+done
+
+echo "Removing excluded libraries from AppDir before linuxdeploy"
+for library in "${EXCLUDE_LIBRARIES[@]}"; do
+    while IFS= read -r -d '' file; do
+        rm -f "$file"
+        echo "Removed: $file"
+    done < <(find "$APPDIR" \( -type f -o -type l \) -name "$library" -print0 2>/dev/null)
+done
+
+echo "Removing leftover doc/metadata dirs for excluded libraries"
+EXCLUDE_DOC_DIRS=(
+    "libpulse0"
+)
+for pkg in "${EXCLUDE_DOC_DIRS[@]}"; do
+    doc_dir="$APPDIR/usr/share/doc/$pkg"
+    if [ -d "$doc_dir" ]; then
+        rm -rf "$doc_dir"
+        echo "Removed doc dir: $doc_dir"
+    fi
+done
+
+jack_library="$(find /usr/lib* \( -type f -o -type l \) -name 'libjack.so.0' 2>/dev/null | head -n 1)"
+if [ -n "$jack_library" ]; then
+    echo "Including JACK runtime library: $jack_library"
+    LIBRARIES+=( "--library=$jack_library" )
+else
+    echo "WARNING: libjack.so.0 not found on host; AppImage may fail on systems without JACK runtime"
+fi
+
+env LINUXDEPLOY_PLUGIN_MODE=1 "$LINUXDEPLOY" --appdir="$APPDIR" "${EXCLUDE_ARGS[@]}" "${LIBRARIES[@]}"
+
+# Create symbolic links as a workaround
+# Details: https://github.com/linuxdeploy/linuxdeploy-plugin-gtk/issues/24#issuecomment-1030026529
+echo "Manually setting rpath for GTK modules"
+PATCH_ARRAY=(
+    "$gtk3_immodulesdir"
+    "$gtk3_printbackendsdir"
+    "$gdk_pixbuf_moduledir"
+)
+for directory in "${PATCH_ARRAY[@]}"; do
+    while IFS= read -r -d '' file; do
+        ln $verbose -s "${file/\/usr\/lib\//}" "$APPDIR/usr/lib"
+    done < <(find "$directory" -name '*.so' -print0)
+done
+
+# set write permission on lib64 again to make it deletable.
+chmod +w "$APPDIR"/usr/lib64 || true
+
+# We have to copy the files first to not get permission errors when we assign gio_extras_dir
+find /usr/lib* -name libgiognutls.so -exec mkdir -p "$APPDIR"/"$(dirname '{}')" \; -exec cp --parents '{}' "$APPDIR/" \; || true
+# related files that we seemingly don't need:
+# libgiolibproxy.so - libgiognomeproxy.so - glib-pacrunner
+
+gio_extras_dir=$(find "$APPDIR"/usr/lib* -name libgiognutls.so -exec dirname '{}' \; 2>/dev/null)
+cat >> "$HOOKFILE" <<EOF
+export GIO_EXTRA_MODULES="\$APPDIR/${gio_extras_dir#"$APPDIR"/}"
+EOF
+
+#binary patch absolute paths in libwebkit files
+find "$APPDIR"/usr/lib* -name 'libwebkit*' -exec sed -i -e "s|/usr|././|g" '{}' \;

--- a/apps/tv-tauri/scripts/linuxdeploy-plugin-gtk.sh
+++ b/apps/tv-tauri/scripts/linuxdeploy-plugin-gtk.sh
@@ -293,56 +293,26 @@ for (( i=0; i<${#FIND_ARRAY[@]}; i+=2 )); do
     done < <(find "$directory" \( -type l -o -type f \) -name "$library" -print0)
 done
 
+# Exclude ONLY the libraries that MUST come from the host because they are coupled to the host's GPU driver,
+# display server, or Wayland compositor. Bundling any of these makes them shadow the host's driver-matched
+# copies, which is what broke WebKitGTK's EGL on Omarchy/virgl ("Could not create default EGL display").
+#
+# Everything else (libselinux, libapparmor, libssl, X11 client libs, pulse, systemd/udev/dbus, ...) is left
+# to be bundled normally. soia's upstream list also excluded those, but that assumes a Ubuntu/Fedora host
+# that ships them — a minimal distro like Arch/Omarchy does NOT have libselinux/libapparmor, so excluding
+# them makes the AppImage fail to start ("libselinux.so.1: cannot open"). Bundling them (as Tauri's default
+# plugin already did) keeps the AppImage self-contained and portable across distros.
 EXCLUDE_LIBRARIES=(
     "libwayland-client.so.0"
     "libwayland-cursor.so.0"
     "libwayland-egl.so.1"
     "libwayland-server.so.0"
-    "libudev.so.1"
-    "libsystemd.so.0"
-    "libcap.so.2"
-    "libdbus-1.so.3"
     "libvulkan.so.1"
     "libva.so.2"
     "libva-drm.so.2"
     "libva-x11.so.2"
     "libvdpau.so.1"
     "libdrm.so.2"
-    "libselinux.so.1"
-    "libapparmor.so.1"
-    "libseccomp.so.2"
-    "libacl.so.1"
-    "libkeyutils.so.1"
-    "libgudev-1.0.so.0"
-    "libmount.so.1"
-    "libblkid.so.1"
-    "libcups.so.2"
-    "libssl.so.3"
-    "libcrypto.so.3"
-    "libkrb5.so.3"
-    "libkrb5support.so.0"
-    "libgssapi_krb5.so.2"
-    "libk5crypto.so.3"
-    "libXau.so.6"
-    "libXcomposite.so.1"
-    "libXcursor.so.1"
-    "libXdamage.so.1"
-    "libXdmcp.so.6"
-    "libXext.so.6"
-    "libXfixes.so.3"
-    "libXinerama.so.1"
-    "libXi.so.6"
-    "libXpresent.so.1"
-    "libXrandr.so.2"
-    "libXrender.so.1"
-    "libXss.so.1"
-    "libXv.so.1"
-    "libxcb-render.so.0"
-    "libxcb-shape.so.0"
-    "libxcb-shm.so.0"
-    "libxcb-xfixes.so.0"
-    "libpulse.so.0"
-    "libpulsecommon-16.1.so"
 )
 EXCLUDE_ARGS=()
 for library in "${EXCLUDE_LIBRARIES[@]}"; do

--- a/apps/tv-tauri/src-tauri/Cargo.lock
+++ b/apps/tv-tauri/src-tauri/Cargo.lock
@@ -22,8 +22,10 @@ name = "airwave"
 version = "0.13.37"
 dependencies = [
  "futures",
+ "gtk",
  "if-addrs",
  "keepawake",
+ "libc",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -41,6 +43,8 @@ dependencies = [
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
+ "wayland-client",
+ "wayland-egl",
  "windows-sys 0.61.2",
 ]
 
@@ -968,6 +972,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading 0.8.9",
+]
+
+[[package]]
 name = "dlopen2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,6 +1026,12 @@ dependencies = [
  "selectors",
  "tendril",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -2286,7 +2305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -2313,6 +2332,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3619,6 +3648,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -5230,6 +5265,64 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.13.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-egl"
+version = "0.32.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b97bdb7c49e5bd9b7562f38ff84f0dad47079fdc9e926f691a787f6dbc05451"
+dependencies = [
+ "wayland-backend",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
 ]
 
 [[package]]

--- a/apps/tv-tauri/src-tauri/Cargo.lock
+++ b/apps/tv-tauri/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "airwave"
-version = "0.13.37"
+version = "0.13.39"
 dependencies = [
  "futures",
  "gtk",

--- a/apps/tv-tauri/src-tauri/Cargo.lock
+++ b/apps/tv-tauri/src-tauri/Cargo.lock
@@ -22,13 +22,8 @@ name = "airwave"
 version = "0.13.37"
 dependencies = [
  "futures",
- "gdkwayland",
- "gdkx11",
- "gtk",
  "if-addrs",
  "keepawake",
- "libc",
- "libloading 0.8.9",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -233,7 +228,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.5",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -284,12 +279,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,9 +301,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.2"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ded4057c258ba199e2d26386d3af3780957ecaee6c4ef4041c6b4b8b97c0b06"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -413,7 +402,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -476,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.5"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -525,12 +514,12 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.1",
+ "cpufeatures 0.3.0",
  "rand_core",
 ]
 
@@ -548,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.6.8"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
@@ -626,7 +615,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
@@ -639,16 +628,10 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "libc",
 ]
-
-[[package]]
-name = "core_detect"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
 
 [[package]]
 name = "cpufeatures"
@@ -661,36 +644,36 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.5.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a7799fd6b852db0e61728dde9a204c423b44d689dbd432522543614b490e78"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.17"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b0cc327b5bc766e7fda9c9260cc0fa81b43a8e240440422dff70788e3f9ef1"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.23"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -753,12 +736,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.24.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.24.1",
- "darling_macro 0.24.1",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -777,15 +760,15 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.24.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 3.0.5",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -801,13 +784,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.24.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.24.1",
+ "darling_core 0.23.0",
  "quote",
- "syn 3.0.5",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -967,7 +950,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -981,16 +964,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.5",
-]
-
-[[package]]
-name = "dlib"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
-dependencies = [
- "libloading 0.8.9",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1039,12 +1013,6 @@ dependencies = [
  "selectors",
  "tendril",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -1106,7 +1074,7 @@ dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 1.1.6+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "vswhom",
  "winreg",
 ]
@@ -1119,17 +1087,11 @@ checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.41"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5ef0006ac9ab233c38522f5ae99cae3625151de8f706cacee1cba4b8e2832a"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
- "core_detect",
- "multiversion",
- "multiversion_no_op",
- "rustversion",
- "scopeguard",
- "simdutf8",
 ]
 
 [[package]]
@@ -1246,7 +1208,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
  "rustc_version",
 ]
 
@@ -1262,19 +1224,18 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.12"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
-version = "1.1.10"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.9.1",
- "zlib-rs",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1307,7 +1268,7 @@ checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.5",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1394,7 +1355,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.5",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1482,20 +1443,6 @@ dependencies = [
  "pango-sys",
  "pkg-config",
  "system-deps",
-]
-
-[[package]]
-name = "gdkwayland"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a934bf3642423de7aafe958c2c4184f511b3111dc9271f0b348b52efe537a"
-dependencies = [
- "gdk",
- "gdkwayland-sys",
- "glib",
- "libc",
- "wayland-backend",
- "wayland-client",
 ]
 
 [[package]]
@@ -1636,7 +1583,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1748,9 +1695,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.19"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1758,7 +1705,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.2",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1788,12 +1735,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
@@ -1858,9 +1799,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.11.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2022,9 +1963,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2085,9 +2026,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.2"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -2105,21 +2046,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "ipnet"
-version = "2.12.2"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "itoa"
@@ -2152,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.37"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1baf72f08796de0260609515130699b890ac25f30e610ad894bc5856cafdb"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -2169,19 +2099,18 @@ dependencies = [
 
 [[package]]
 name = "jiff-core"
-version = "0.1.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e52fe76043ccecc9005d2305ebaadf7d7fc0cc89ca6baa10a94d6bc68c7128c"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
  "defmt",
- "log",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.37"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "378268a1116ad67ae6228701118ac9f491d78fda38a40a1f1a9e1348de6f7212"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
  "jiff-core",
  "proc-macro2",
@@ -2280,9 +2209,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.105"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2332,7 +2261,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "serde",
  "unicode-segmentation",
 ]
@@ -2357,7 +2286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading 0.7.4",
+ "libloading",
  "once_cell",
 ]
 
@@ -2387,20 +2316,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "libredox"
-version = "0.1.24"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6480ccc157a1389bb2e4891b24751b0f798ba640d22386f23143fbcc89da195a"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]
@@ -2434,9 +2353,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.34"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -2460,15 +2379,6 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "memoffset"
@@ -2502,20 +2412,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
-
-[[package]]
 name = "mio"
-version = "1.2.3"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -2544,39 +2444,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "multiversion"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ca4bea16ffc3f443cf7d866912118196bfef4c6a1556ca00f9f9b00bb43f7c"
-dependencies = [
- "multiversion-macros",
-]
-
-[[package]]
-name = "multiversion-macros"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d416831a7317ef4b08bee00b69cbbb9c8763da7959a7026244d6266869f9c83"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 3.0.5",
-]
-
-[[package]]
-name = "multiversion_no_op"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743fb55ba31b18fb1ecef6bdc9aa2743314978ac084044301a7eee33fb99a20d"
-
-[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -2602,23 +2475,11 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.7.1",
-]
-
-[[package]]
-name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2686,7 +2547,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -2707,7 +2568,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2718,7 +2579,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2729,7 +2590,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "block2",
  "dispatch2",
  "libc",
@@ -2742,7 +2603,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -2775,7 +2636,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2787,7 +2648,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2815,7 +2676,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -2828,7 +2689,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "block2",
  "dispatch2",
  "libc",
@@ -2842,7 +2703,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2853,7 +2714,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2864,7 +2725,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -2876,7 +2737,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -2893,7 +2754,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -2924,7 +2785,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-app-kit",
@@ -2968,7 +2829,7 @@ checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
 dependencies = [
  "android_system_properties",
  "log",
- "nix 0.31.3",
+ "nix",
  "objc2",
  "objc2-foundation",
  "objc2-ui-kit",
@@ -3128,13 +2989,13 @@ checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plist"
-version = "1.10.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896bade328c13f7042a297ea5ac5b0951f6cf989dea5f32c2fd98da398195cb"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
- "base64 0.23.1",
- "indexmap 2.14.2",
- "quick-xml 0.42.0",
+ "base64 0.22.1",
+ "indexmap 2.14.0",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -3149,7 +3010,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.8.9",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -3158,11 +3019,11 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.8.9",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -3173,7 +3034,7 @@ checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.5.3",
+ "hermit-abi",
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
@@ -3187,9 +3048,9 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.8"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -3241,7 +3102,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.15+spec-1.1.0",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -3295,18 +3156,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.28.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -3426,7 +3278,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3457,7 +3309,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.5",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3534,11 +3386,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.5"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a1cfa75cc186dd73d5818e510e042e40927bccc9c236b061cea97e1eb08029"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64 0.23.1",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3606,7 +3458,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3615,9 +3467,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.44"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "once_cell",
  "ring",
@@ -3678,9 +3530,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.15"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3769,12 +3621,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3786,7 +3632,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3809,7 +3655,7 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "cssparser",
  "derive_more",
  "log",
@@ -3871,7 +3717,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.5",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3906,7 +3752,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.5",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3941,16 +3787,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.23.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935177bb8c0cd8ca1a4e6d1a2ac8988bea69cab4f9d3a31311e012ad27868ea4"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
- "base64 0.23.1",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.14.2",
+ "indexmap 2.14.0",
  "jiff",
  "schemars 0.9.0",
  "schemars 1.2.2",
@@ -3962,14 +3808,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.23.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d607aa01a3cb0ad757d6fd216136910db3c97b102fe686585689615a02dbcdc"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
 dependencies = [
- "darling 0.24.1",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 3.0.5",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4066,9 +3912,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.16.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba467056f1b547ed52077911161fc86985becbc60e8e1857c8a144dab0def891"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
@@ -4204,9 +4050,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.5"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4248,7 +4094,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4282,7 +4128,7 @@ version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "block2",
  "core-foundation 0.10.1",
  "core-graphics",
@@ -4374,7 +4220,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.13.5",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4475,9 +4321,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.5.2"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de22eef34fd78c0da050e748710edd50bf127e651d02ea1b2bfada1523cc5c51"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
 dependencies = [
  "anyhow",
  "dunce",
@@ -4493,15 +4339,15 @@ dependencies = [
  "tauri-plugin",
  "tauri-utils",
  "thiserror 2.0.20",
- "toml 1.1.6+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "url",
 ]
 
 [[package]]
 name = "tauri-plugin-http"
-version = "2.6.0"
+version = "2.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7241a0c762649be8fba7dd4cc84684d0e409f26b335a978ef4dd5fe78da74ce6"
+checksum = "b5bd512048e1985b7ec78f96d99083e2ddaf7e0d906b2b63c44ce5bb8b894067"
 dependencies = [
  "bytes",
  "cookie_store",
@@ -4523,9 +4369,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-log"
-version = "2.9.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4e8861142c21636b03ff6eb9682a073814112e35220435670738a8be7b49896"
+checksum = "6792296e6f389268016c77db21ebae1fc0568f2fccf88b1ec7e2ea71330afb4c"
 dependencies = [
  "android_logger",
  "fern",
@@ -4588,9 +4434,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-updater"
-version = "2.11.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28d8cabdeb0564f03ae261963de4bc3d98321cd3d213e76a81b7d344e5df606"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
 dependencies = [
  "base64 0.22.1",
  "dirs",
@@ -4602,7 +4448,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest 0.13.5",
+ "reqwest 0.13.4",
  "rustls",
  "semver",
  "serde",
@@ -4625,7 +4471,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "log",
  "serde",
  "serde_json",
@@ -4716,7 +4562,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.20",
- "toml 1.1.6+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -4731,7 +4577,7 @@ checksum = "cc65d45c68858bfe420dd29e834b5d15dbecf8a07a8a16cf4d532c7b1f69d4b6"
 dependencies = [
  "dunce",
  "embed-resource",
- "toml 1.1.6+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -4793,7 +4639,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.5",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4840,9 +4686,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.13.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4876,14 +4722,14 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.5",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.5"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -4921,7 +4767,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.14.2",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -4932,11 +4778,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.6+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "920602543f0911ab71da12c50d59701da54c196d1a2bf5cb4b75667f137a406a"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
- "indexmap 2.14.2",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -4978,7 +4824,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.14.2",
+ "indexmap 2.14.0",
  "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]
@@ -4989,7 +4835,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.14.2",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
@@ -4998,11 +4844,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.15+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1340ea94a5856333492c9064b02c778b191dd2c853778d9609debdcdfea3a614"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap 2.14.2",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.4",
@@ -5044,7 +4890,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.2",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -5145,7 +4991,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
  "tempfile",
  "windows-sys 0.61.2",
 ]
@@ -5242,9 +5088,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.26.1"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef6dac1e96601b4fb3acccccff2139741fcb757cb9a36089bf5be91cfb285ce"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -5320,9 +5166,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.128"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5333,9 +5179,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.78"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5343,9 +5189,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.128"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5353,22 +5199,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.128"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 3.0.5",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.128"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -5387,59 +5233,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wayland-backend"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b48e27457e8da3b2260ac60d0a94512f5cba36448679f3747c0865b7893ed8"
-dependencies = [
- "cc",
- "downcast-rs",
- "io-lifetimes",
- "nix 0.26.4",
- "scoped-tls",
- "smallvec",
- "wayland-sys",
-]
-
-[[package]]
-name = "wayland-client"
-version = "0.30.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489c9654770f674fc7e266b3c579f4053d7551df0ceb392f153adb1f9ed06ac8"
-dependencies = [
- "bitflags 1.3.2",
- "nix 0.26.4",
- "wayland-backend",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-scanner"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b873b257fbc32ec909c0eb80dea312076a67014e65e245f5eb69a6b8ab330e"
-dependencies = [
- "proc-macro2",
- "quick-xml 0.28.2",
- "quote",
-]
-
-[[package]]
-name = "wayland-sys"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b2a02ac608e07132978689a6f9bf4214949c85998c247abadd4f4129b1aa06"
-dependencies = [
- "dlib",
- "log",
- "pkg-config",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.105"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5814,15 +5611,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5870,21 +5658,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5955,12 +5728,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5979,12 +5746,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6000,12 +5761,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6039,12 +5794,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6060,12 +5809,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6087,12 +5830,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6108,12 +5845,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6315,7 +6046,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 3.0.5",
+ "syn 3.0.3",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -6392,13 +6123,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.6"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.5",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6409,15 +6140,9 @@ checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "indexmap 2.14.2",
+ "indexmap 2.14.0",
  "memchr",
 ]
-
-[[package]]
-name = "zlib-rs"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
@@ -6449,7 +6174,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 3.0.5",
+ "syn 3.0.3",
  "zvariant_utils",
 ]
 
@@ -6462,6 +6187,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 3.0.5",
+ "syn 3.0.3",
  "winnow 1.0.4",
 ]

--- a/apps/tv-tauri/src-tauri/Cargo.lock
+++ b/apps/tv-tauri/src-tauri/Cargo.lock
@@ -22,8 +22,13 @@ name = "airwave"
 version = "0.13.37"
 dependencies = [
  "futures",
+ "gdkwayland",
+ "gdkx11",
+ "gtk",
  "if-addrs",
  "keepawake",
+ "libc",
+ "libloading 0.8.9",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -228,7 +233,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -279,6 +284,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,9 +312,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+checksum = "3ded4057c258ba199e2d26386d3af3780957ecaee6c4ef4041c6b4b8b97c0b06"
 dependencies = [
  "serde_core",
 ]
@@ -402,7 +413,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -465,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -514,12 +525,12 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core",
 ]
 
@@ -537,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -615,7 +626,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
@@ -628,10 +639,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "core-foundation 0.10.1",
  "libc",
 ]
+
+[[package]]
+name = "core_detect"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
 
 [[package]]
 name = "cpufeatures"
@@ -644,36 +661,36 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "01a7799fd6b852db0e61728dde9a204c423b44d689dbd432522543614b490e78"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.16"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+checksum = "98b0cc327b5bc766e7fda9c9260cc0fa81b43a8e240440422dff70788e3f9ef1"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crypto-common"
@@ -736,12 +753,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
 ]
 
 [[package]]
@@ -760,15 +777,15 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -784,13 +801,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core 0.24.1",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -950,7 +967,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "block2",
  "libc",
  "objc2",
@@ -964,7 +981,16 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -1013,6 +1039,12 @@ dependencies = [
  "selectors",
  "tendril",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -1074,7 +1106,7 @@ dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.6+spec-1.1.0",
  "vswhom",
  "winreg",
 ]
@@ -1087,11 +1119,17 @@ checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.35"
+version = "0.8.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+checksum = "7b5ef0006ac9ab233c38522f5ae99cae3625151de8f706cacee1cba4b8e2832a"
 dependencies = [
  "cfg-if",
+ "core_detect",
+ "multiversion",
+ "multiversion_no_op",
+ "rustversion",
+ "scopeguard",
+ "simdutf8",
 ]
 
 [[package]]
@@ -1208,7 +1246,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "rustc_version",
 ]
 
@@ -1224,18 +1262,19 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1268,7 +1307,7 @@ checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1355,7 +1394,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1443,6 +1482,20 @@ dependencies = [
  "pango-sys",
  "pkg-config",
  "system-deps",
+]
+
+[[package]]
+name = "gdkwayland"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4a934bf3642423de7aafe958c2c4184f511b3111dc9271f0b348b52efe537a"
+dependencies = [
+ "gdk",
+ "gdkwayland-sys",
+ "glib",
+ "libc",
+ "wayland-backend",
+ "wayland-client",
 ]
 
 [[package]]
@@ -1583,7 +1636,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1695,9 +1748,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1705,7 +1758,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "slab",
  "tokio",
  "tokio-util",
@@ -1735,6 +1788,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
@@ -1799,9 +1858,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1963,9 +2022,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2026,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -2046,10 +2105,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.12.1"
+name = "io-lifetimes"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
 
 [[package]]
 name = "itoa"
@@ -2082,9 +2152,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.35"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+checksum = "0ab1baf72f08796de0260609515130699b890ac25f30e610ad894bc5856cafdb"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -2099,18 +2169,19 @@ dependencies = [
 
 [[package]]
 name = "jiff-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+checksum = "5e52fe76043ccecc9005d2305ebaadf7d7fc0cc89ca6baa10a94d6bc68c7128c"
 dependencies = [
  "defmt",
+ "log",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.35"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+checksum = "378268a1116ad67ae6228701118ac9f491d78fda38a40a1f1a9e1348de6f7212"
 dependencies = [
  "jiff-core",
  "proc-macro2",
@@ -2209,9 +2280,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2261,7 +2332,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "serde",
  "unicode-segmentation",
 ]
@@ -2286,7 +2357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -2316,10 +2387,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.20"
+name = "libloading"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6480ccc157a1389bb2e4891b24751b0f798ba640d22386f23143fbcc89da195a"
 dependencies = [
  "libc",
 ]
@@ -2353,9 +2434,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru-slab"
@@ -2379,6 +2460,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "memoffset"
@@ -2412,10 +2502,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.2.2"
+name = "miniz_oxide"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi",
@@ -2444,12 +2544,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiversion"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ca4bea16ffc3f443cf7d866912118196bfef4c6a1556ca00f9f9b00bb43f7c"
+dependencies = [
+ "multiversion-macros",
+]
+
+[[package]]
+name = "multiversion-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d416831a7317ef4b08bee00b69cbbb9c8763da7959a7026244d6266869f9c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "multiversion_no_op"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743fb55ba31b18fb1ecef6bdc9aa2743314978ac084044301a7eee33fb99a20d"
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -2475,11 +2602,23 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+]
+
+[[package]]
+name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2547,7 +2686,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "block2",
  "libc",
  "objc2",
@@ -2568,7 +2707,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "objc2",
  "objc2-foundation",
 ]
@@ -2579,7 +2718,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "objc2",
  "objc2-foundation",
 ]
@@ -2590,7 +2729,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "block2",
  "dispatch2",
  "libc",
@@ -2603,7 +2742,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -2636,7 +2775,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2648,7 +2787,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2676,7 +2815,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "block2",
  "libc",
  "objc2",
@@ -2689,7 +2828,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "block2",
  "dispatch2",
  "libc",
@@ -2703,7 +2842,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2714,7 +2853,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "objc2",
  "objc2-foundation",
 ]
@@ -2725,7 +2864,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -2737,7 +2876,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "block2",
  "libc",
  "objc2",
@@ -2754,7 +2893,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -2785,7 +2924,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "block2",
  "objc2",
  "objc2-app-kit",
@@ -2829,7 +2968,7 @@ checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
 dependencies = [
  "android_system_properties",
  "log",
- "nix",
+ "nix 0.31.3",
  "objc2",
  "objc2-foundation",
  "objc2-ui-kit",
@@ -2989,13 +3128,13 @@ checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plist"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
+checksum = "2896bade328c13f7042a297ea5ac5b0951f6cf989dea5f32c2fd98da398195cb"
 dependencies = [
- "base64 0.22.1",
- "indexmap 2.14.0",
- "quick-xml",
+ "base64 0.23.1",
+ "indexmap 2.14.2",
+ "quick-xml 0.42.0",
  "serde",
  "time",
 ]
@@ -3010,7 +3149,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -3019,11 +3158,11 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -3034,7 +3173,7 @@ checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.5.3",
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
@@ -3048,9 +3187,9 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
 dependencies = [
  "portable-atomic",
 ]
@@ -3102,7 +3241,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.13+spec-1.1.0",
+ "toml_edit 0.25.15+spec-1.1.0",
 ]
 
 [[package]]
@@ -3156,9 +3295,18 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
 ]
@@ -3278,7 +3426,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
 ]
 
 [[package]]
@@ -3309,7 +3457,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3386,11 +3534,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+checksum = "16a1cfa75cc186dd73d5818e510e042e40927bccc9c236b061cea97e1eb08029"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3458,7 +3606,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3467,9 +3615,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "once_cell",
  "ring",
@@ -3530,9 +3678,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.14"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3621,6 +3769,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3632,7 +3786,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3655,7 +3809,7 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "cssparser",
  "derive_more",
  "log",
@@ -3717,7 +3871,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3752,7 +3906,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3787,16 +3941,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
+checksum = "935177bb8c0cd8ca1a4e6d1a2ac8988bea69cab4f9d3a31311e012ad27868ea4"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "jiff",
  "schemars 0.9.0",
  "schemars 1.2.2",
@@ -3808,14 +3962,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
+checksum = "1d607aa01a3cb0ad757d6fd216136910db3c97b102fe686585689615a02dbcdc"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.1",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3912,9 +4066,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "ba467056f1b547ed52077911161fc86985becbc60e8e1857c8a144dab0def891"
 
 [[package]]
 name = "socket2"
@@ -4050,9 +4204,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4094,7 +4248,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4128,7 +4282,7 @@ version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "block2",
  "core-foundation 0.10.1",
  "core-graphics",
@@ -4220,7 +4374,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4321,9 +4475,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+checksum = "de22eef34fd78c0da050e748710edd50bf127e651d02ea1b2bfada1523cc5c51"
 dependencies = [
  "anyhow",
  "dunce",
@@ -4339,15 +4493,15 @@ dependencies = [
  "tauri-plugin",
  "tauri-utils",
  "thiserror 2.0.20",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.6+spec-1.1.0",
  "url",
 ]
 
 [[package]]
 name = "tauri-plugin-http"
-version = "2.5.9"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bd512048e1985b7ec78f96d99083e2ddaf7e0d906b2b63c44ce5bb8b894067"
+checksum = "7241a0c762649be8fba7dd4cc84684d0e409f26b335a978ef4dd5fe78da74ce6"
 dependencies = [
  "bytes",
  "cookie_store",
@@ -4369,9 +4523,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-log"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6792296e6f389268016c77db21ebae1fc0568f2fccf88b1ec7e2ea71330afb4c"
+checksum = "b4e8861142c21636b03ff6eb9682a073814112e35220435670738a8be7b49896"
 dependencies = [
  "android_logger",
  "fern",
@@ -4434,9 +4588,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-updater"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+checksum = "b28d8cabdeb0564f03ae261963de4bc3d98321cd3d213e76a81b7d344e5df606"
 dependencies = [
  "base64 0.22.1",
  "dirs",
@@ -4448,7 +4602,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "rustls",
  "semver",
  "serde",
@@ -4471,7 +4625,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "log",
  "serde",
  "serde_json",
@@ -4562,7 +4716,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.20",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.6+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -4577,7 +4731,7 @@ checksum = "cc65d45c68858bfe420dd29e834b5d15dbecf8a07a8a16cf4d532c7b1f69d4b6"
 dependencies = [
  "dunce",
  "embed-resource",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.6+spec-1.1.0",
 ]
 
 [[package]]
@@ -4639,7 +4793,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4686,9 +4840,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4722,14 +4876,14 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",
@@ -4767,7 +4921,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -4778,11 +4932,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "920602543f0911ab71da12c50d59701da54c196d1a2bf5cb4b75667f137a406a"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -4824,7 +4978,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]
@@ -4835,7 +4989,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
@@ -4844,11 +4998,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.13+spec-1.1.0"
+version = "0.25.15+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+checksum = "1340ea94a5856333492c9064b02c778b191dd2c853778d9609debdcdfea3a614"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.4",
@@ -4890,7 +5044,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "bytes",
  "futures-util",
  "http",
@@ -4991,7 +5145,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "tempfile",
  "windows-sys 0.61.2",
 ]
@@ -5088,9 +5242,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.24.1"
+version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+checksum = "2ef6dac1e96601b4fb3acccccff2139741fcb757cb9a36089bf5be91cfb285ce"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -5166,9 +5320,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5179,9 +5333,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5189,9 +5343,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5199,22 +5353,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -5233,10 +5387,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.104"
+name = "wayland-backend"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "41b48e27457e8da3b2260ac60d0a94512f5cba36448679f3747c0865b7893ed8"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "io-lifetimes",
+ "nix 0.26.4",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489c9654770f674fc7e266b3c579f4053d7551df0ceb392f153adb1f9ed06ac8"
+dependencies = [
+ "bitflags 1.3.2",
+ "nix 0.26.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b873b257fbc32ec909c0eb80dea312076a67014e65e245f5eb69a6b8ab330e"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.28.2",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b2a02ac608e07132978689a6f9bf4214949c85998c247abadd4f4129b1aa06"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5611,6 +5814,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5658,6 +5870,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5728,6 +5955,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5746,6 +5979,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5761,6 +6000,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5794,6 +6039,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5809,6 +6060,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5830,6 +6087,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5845,6 +6108,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6046,7 +6315,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -6123,13 +6392,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -6140,9 +6409,15 @@ checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "memchr",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
@@ -6174,7 +6449,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
  "zvariant_utils",
 ]
 
@@ -6187,6 +6462,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 3.0.3",
+ "syn 3.0.5",
  "winnow 1.0.4",
 ]

--- a/apps/tv-tauri/src-tauri/Cargo.toml
+++ b/apps/tv-tauri/src-tauri/Cargo.toml
@@ -68,7 +68,6 @@ objc2-quartz-core = { version = "0.3.1", features = ["CALayer", "CAMetalLayer"] 
 gtk = "0.18"
 gdkwayland = "0.18"
 gdkx11 = "0.18"
-epoxy = "0.1"
 libloading = "0.8"
 
 # Keep the machine + display awake while video plays (desktop only). Tauri has no first-class API

--- a/apps/tv-tauri/src-tauri/Cargo.toml
+++ b/apps/tv-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "airwave"
-version = "0.13.37"
+version = "0.13.39"
 description = "Airwave desktop client (Tauri + libmpv)"
 authors = ["Airwave"]
 license = ""

--- a/apps/tv-tauri/src-tauri/Cargo.toml
+++ b/apps/tv-tauri/src-tauri/Cargo.toml
@@ -69,6 +69,9 @@ gtk = "0.18"
 gdkwayland = "0.18"
 gdkx11 = "0.18"
 libloading = "0.8"
+# setlocale(LC_NUMERIC, "C") before mpv_create — mandatory or mpv_create() returns null on non-C locales
+# (glibc/AppImage runtimes set a non-C LC_NUMERIC). See mpv/mod.rs and plezy mpv_player.cc:35.
+libc = "0.2"
 
 # Keep the machine + display awake while video plays (desktop only). Tauri has no first-class API
 # (tauri#3697), so we mirror our Tauri+libmpv reference (soia): hold an OS wake assertion during playback.

--- a/apps/tv-tauri/src-tauri/Cargo.toml
+++ b/apps/tv-tauri/src-tauri/Cargo.toml
@@ -61,14 +61,15 @@ objc2-app-kit = { version = "0.3.1", features = ["NSWindow", "NSView", "NSRespon
 objc2-foundation = { version = "0.3.1", features = ["NSString", "NSGeometry"] }
 objc2-quartz-core = { version = "0.3.1", features = ["CALayer", "CAMetalLayer"] }
 
-# Linux: GTK (must match Tauri's gtk version) for the GLArea video surface behind the WebKitGTK webview,
-# the gdk Wayland/X11 backends to pass the display handle to mpv for VAAPI, and epoxy to resolve GL procs
-# for the mpv render context. mpv itself is linked via build.rs (libmpv.so). Render API — no `wid`.
+# Linux: video is a Wayland subsurface behind the transparent WebKitGTK webview (soia's model, NO GTK
+# reparent). wayland-client marshals the compositor/subcompositor/surface/subsurface on the toplevel's
+# foreign wl_display; wayland-egl gives the wl_egl_window; EGL itself is linked (host libEGL, never bundled)
+# via a #[link] block in render_linux.rs. gtk stays only for the glib main-loop channel (render pump).
+# mpv is linked via build.rs (libmpv.so). Render API — no `wid`.
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18"
-gdkwayland = "0.18"
-gdkx11 = "0.18"
-libloading = "0.8"
+wayland-client = "0.31"
+wayland-egl = "0.32"
 # setlocale(LC_NUMERIC, "C") before mpv_create — mandatory or mpv_create() returns null on non-C locales
 # (glibc/AppImage runtimes set a non-C LC_NUMERIC). See mpv/mod.rs and plezy mpv_player.cc:35.
 libc = "0.2"

--- a/apps/tv-tauri/src-tauri/Cargo.toml
+++ b/apps/tv-tauri/src-tauri/Cargo.toml
@@ -61,6 +61,16 @@ objc2-app-kit = { version = "0.3.1", features = ["NSWindow", "NSView", "NSRespon
 objc2-foundation = { version = "0.3.1", features = ["NSString", "NSGeometry"] }
 objc2-quartz-core = { version = "0.3.1", features = ["CALayer", "CAMetalLayer"] }
 
+# Linux: GTK (must match Tauri's gtk version) for the GLArea video surface behind the WebKitGTK webview,
+# the gdk Wayland/X11 backends to pass the display handle to mpv for VAAPI, and epoxy to resolve GL procs
+# for the mpv render context. mpv itself is linked via build.rs (libmpv.so). Render API — no `wid`.
+[target.'cfg(target_os = "linux")'.dependencies]
+gtk = "0.18"
+gdkwayland = "0.18"
+gdkx11 = "0.18"
+epoxy = "0.1"
+libloading = "0.8"
+
 # Keep the machine + display awake while video plays (desktop only). Tauri has no first-class API
 # (tauri#3697), so we mirror our Tauri+libmpv reference (soia): hold an OS wake assertion during playback.
 # keepawake → IOPMAssertion (macOS) / SetThreadExecutionState (Windows) / D-Bus·systemd (Linux). Scoped to

--- a/apps/tv-tauri/src-tauri/src/lib.rs
+++ b/apps/tv-tauri/src-tauri/src/lib.rs
@@ -598,7 +598,14 @@ fn setup_player(app: &mut tauri::App) -> Result<(), String> {
     {
         mpv.set_option_string("vo", "libmpv")?; // enable the render API
         mpv.initialize()?;
-        render_linux::setup(&window, &mpv)?;
+        // STEP 1 (base validation): the GtkGLArea + GtkOverlay reparent breaks the webview — it panics
+        // Tauri's undecorated-resizing handler (unwrap on Err: Widget GtkOverlay, tauri-runtime-wry
+        // undecorated_resizing.rs:546) and blanks the UI. soia never reparents GTK widgets. So skip the
+        // reparent to confirm the webview renders cleanly; STEP 2 adds video the soia way — a wl_subsurface
+        // below the webview + a platform-EGL surface, no GTK reparent.
+        let _ = &window;
+        log::warn!("linux video: reparent disabled (pending soia wl_subsurface path); UI-only validation");
+        // render_linux::setup(&window, &mpv)?;
     }
     #[cfg(target_os = "windows")]
     {

--- a/apps/tv-tauri/src-tauri/src/lib.rs
+++ b/apps/tv-tauri/src-tauri/src/lib.rs
@@ -1,6 +1,8 @@
 mod mpv;
 #[cfg(target_os = "macos")]
 mod render_macos;
+#[cfg(target_os = "linux")]
+mod render_linux;
 mod wakelock;
 
 use std::sync::Arc;
@@ -485,11 +487,17 @@ pub fn run() {
             Ok(())
         })
         .on_window_event(|_window, _event| {
-            // macOS render API: refit the GL drawable when the window resizes.
+            // Render-API targets (macOS + Linux): refit the GL drawable when the window resizes.
             #[cfg(target_os = "macos")]
             if let tauri::WindowEvent::Resized(_) = _event {
                 if let Some(w) = _window.get_webview_window("main") {
                     render_macos::on_resize(&w);
+                }
+            }
+            #[cfg(target_os = "linux")]
+            if let tauri::WindowEvent::Resized(_) = _event {
+                if let Some(w) = _window.get_webview_window("main") {
+                    render_linux::on_resize(&w);
                 }
             }
         })
@@ -519,11 +527,12 @@ fn setup_player(app: &mut tauri::App) -> Result<(), String> {
     let mpv = Arc::new(mpv::Mpv::new()?);
     mpv.set_option_string("hwdec", "auto")?; // hardware decode (soia baseline)
 
-    // Video attach is per-platform. Windows/Linux: mpv renders itself into a native surface passed as
-    // `wid` (Windows = the main window HWND under the WebView2 DComp visual) — a pre-init option. macOS:
-    // mpv 0.41 has no embed window context (cocoa/macvk make their own window — see
-    // project-tv-tauri-macos-render), so we use the RENDER API: `vo=libmpv`, then create + drive an
-    // OpenGL render context into a view behind the transparent webview.
+    // Video attach is per-platform, an explicit 3-way split:
+    //  • Windows: mpv renders itself into the main window's HWND, passed as the pre-init `wid` (the video is
+    //    a child HWND under the WebView2 DComp visual). mpv's own gpu-next VO.
+    //  • macOS + Linux: mpv 0.41 has no usable embed-window context, so both use the RENDER API — `vo=libmpv`
+    //    then create + drive an OpenGL `mpv_render_context` into a surface behind the transparent webview
+    //    (macOS: an NSView/CVDisplayLink; Linux: a GTK GLArea). No `wid`.
     #[cfg(target_os = "macos")]
     {
         // Diagnostic: mpv's own verbose log to a predictable file (readable render failures). Non-fatal.
@@ -537,7 +546,13 @@ fn setup_player(app: &mut tauri::App) -> Result<(), String> {
         mpv.initialize()?;
         render_macos::setup(&window, &mpv)?;
     }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
+    {
+        mpv.set_option_string("vo", "libmpv")?; // enable the render API (GLArea render context)
+        mpv.initialize()?;
+        render_linux::setup(&window, &mpv)?;
+    }
+    #[cfg(target_os = "windows")]
     {
         let wid = resolve_video_wid(&window)?;
         mpv.set_option_i64("wid", wid)?;
@@ -569,11 +584,6 @@ fn resolve_video_wid(window: &tauri::WebviewWindow) -> Result<i64, String> {
         RawWindowHandle::Win32(h) => Ok(h.hwnd.get() as i64),
         other => Err(format!("unsupported window handle: {other:?}")),
     }
-}
-
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
-fn resolve_video_wid(_window: &tauri::WebviewWindow) -> Result<i64, String> {
-    Err("video render-attach not implemented on this platform yet".into())
 }
 
 /// macOS: put the window in "full-size content view" with a transparent, title-less titlebar so the

--- a/apps/tv-tauri/src-tauri/src/lib.rs
+++ b/apps/tv-tauri/src-tauri/src/lib.rs
@@ -561,13 +561,7 @@ fn setup_player(app: &mut tauri::App) -> Result<(), String> {
     {
         mpv.set_option_string("vo", "libmpv")?; // enable the render API
         mpv.initialize()?;
-        // DIAGNOSTIC (temporary): the GtkOverlay reparent in render_linux::setup blanks the WebKitGTK
-        // webview. Skip it to confirm the UI renders when the webview is left untouched. If it does, the
-        // reparent is the cause → build the no-reparent wl_subsurface + EGL path (soia's model). Then
-        // restore this call. See .plans/tv-tauri-linux-render.md.
-        let _ = &window;
-        log::warn!("linux video: DIAGNOSTIC — video setup skipped, webview left untouched");
-        // render_linux::setup(&window, &mpv)?;
+        render_linux::setup(&window, &mpv)?;
     }
     #[cfg(target_os = "windows")]
     {

--- a/apps/tv-tauri/src-tauri/src/lib.rs
+++ b/apps/tv-tauri/src-tauri/src/lib.rs
@@ -448,21 +448,53 @@ fn local_subnets() -> Vec<String> {
     prefixes
 }
 
+/// On a virtualized GPU (VM, virgl/Venus) WebKitGTK's WebProcess can't create an EGL display for its
+/// accelerated compositor and hard-aborts ("Could not create default EGL display: EGL_BAD_PARAMETER.
+/// Aborting...") before any window shows — confirmed via coredumpctl to be WebKitWebProcess, unrelated to our
+/// video code (a blank window aborts the same way). Disabling accelerated compositing (webview paints on the
+/// CPU, which is fine — mpv owns video on its own GL path) avoids that EGL display and fixes it.
+///
+/// The catch: WebKit reads `WEBKIT_DISABLE_COMPOSITING_MODE` when libwebkit2gtk LOADS, before `main` runs, so
+/// setting it in-process is too late (verified on-device: it only takes effect when present at process start,
+/// e.g. from the shell). So if it isn't already set, set it and re-exec ourselves — the fresh process starts
+/// with it in the environment before WebKit loads. Guarded against an exec loop; opt out on real GPUs with
+/// `AIRWAVE_NO_WEBKIT_REEXEC=1`. TODO(perf): gate the default on a virtualized-GPU probe before GA.
+#[cfg(target_os = "linux")]
+fn ensure_webkit_env_via_reexec() {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    if std::env::var_os("WEBKIT_DISABLE_COMPOSITING_MODE").is_some()
+        || std::env::var_os("AIRWAVE_NO_WEBKIT_REEXEC").is_some()
+    {
+        return; // already set by the user/shell, or we've already re-exec'd once.
+    }
+    let Ok(exe) = std::env::current_exe() else {
+        return;
+    };
+    let Ok(exe_c) = CString::new(exe.as_os_str().as_bytes()) else {
+        return;
+    };
+    let argv_c: Vec<CString> = std::env::args_os()
+        .filter_map(|a| CString::new(a.as_bytes()).ok())
+        .collect();
+    std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+    std::env::set_var("AIRWAVE_NO_WEBKIT_REEXEC", "1"); // loop guard for the re-exec'd process
+    let mut argv: Vec<*const libc::c_char> = argv_c.iter().map(|a| a.as_ptr()).collect();
+    argv.push(std::ptr::null());
+    // SAFETY: exe_c/argv are valid, NUL-terminated C strings that outlive the call; execv replaces this
+    // process image and only returns on failure.
+    unsafe {
+        libc::execv(exe_c.as_ptr(), argv.as_ptr());
+    }
+    log::error!("re-exec to set WEBKIT_DISABLE_COMPOSITING_MODE failed; continuing (may abort in a VM)");
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    // On a virtualized GPU (VM, virgl/Venus) the WebKitWebProcess — the separate child that renders the page —
-    // can't create an EGL display for its accelerated compositor and hard-aborts ("Could not create default
-    // EGL display: EGL_BAD_PARAMETER. Aborting..."; confirmed via coredumpctl to be WebKitWebProcess, not our
-    // code). Disabling WebKitGTK's accelerated compositing makes the web process paint on the CPU and avoids
-    // that EGL display entirely. Only-if-unset so real-GPU users can re-enable. mpv's own GL surface is a
-    // separate concern in the main process.
-    // NOTE: do NOT also set WEBKIT_DISABLE_DMABUF_RENDERER — on Omarchy, compositing-off + DMABUF-off ABORTED,
-    // while compositing-off + DMABUF-on rendered fine. The DMABUF renderer is also the fast path on real HW.
-    // TODO(perf): compositing-off penalizes real-hardware Linux; gate on a virtualized-GPU probe before GA.
+    // Must run before WebKit's library loads (see the function doc). Linux/VM-only workaround.
     #[cfg(target_os = "linux")]
-    if std::env::var_os("WEBKIT_DISABLE_COMPOSITING_MODE").is_none() {
-        std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
-    }
+    ensure_webkit_env_via_reexec();
     tauri::Builder::default()
         // Log plugin first so it captures everything (Rust `log::*` + JS `@tauri-apps/plugin-log`)
         // to the terminal running `tauri dev`. Registered unconditionally so JS logging works.

--- a/apps/tv-tauri/src-tauri/src/lib.rs
+++ b/apps/tv-tauri/src-tauri/src/lib.rs
@@ -553,14 +553,12 @@ fn setup_player(app: &mut tauri::App) -> Result<(), String> {
     {
         mpv.set_option_string("vo", "libmpv")?; // enable the render API
         mpv.initialize()?;
-        // STEP 1 (base validation): the GtkGLArea + GtkOverlay reparent breaks the webview — it panics
-        // Tauri's undecorated-resizing handler (unwrap on Err: Widget GtkOverlay, tauri-runtime-wry
-        // undecorated_resizing.rs:546) and blanks the UI. soia never reparents GTK widgets. So skip the
-        // reparent to confirm the webview renders cleanly; STEP 2 adds video the soia way — a wl_subsurface
-        // below the webview + a platform-EGL surface, no GTK reparent.
-        let _ = &window;
-        log::warn!("linux video: reparent disabled (pending soia wl_subsurface path); UI-only validation");
-        // render_linux::setup(&window, &mpv)?;
+        // soia model: render video into a wl_subsurface BEHIND the transparent webview (no GTK reparent —
+        // reparenting panics Tauri's undecorated-resizing handler and blanks the UI). Best-effort: a failure
+        // logs and leaves the (working) UI intact rather than aborting the rest of setup.
+        if let Err(e) = render_linux::setup(&window, &mpv) {
+            log::error!("linux video setup failed (UI unaffected): {e}");
+        }
     }
     #[cfg(target_os = "windows")]
     {

--- a/apps/tv-tauri/src-tauri/src/lib.rs
+++ b/apps/tv-tauri/src-tauri/src/lib.rs
@@ -450,13 +450,18 @@ fn local_subnets() -> Vec<String> {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    // WebKitGTK 2.42+ uses a DMABUF GPU renderer that draws a BLANK window on many drivers and especially
-    // virtualized GPUs (VMs) — the classic "Tauri Linux blank window." Disable it before the webview inits
-    // so the UI paints via the fallback path. Our mpv video uses its own GL context and is unaffected. Set
-    // only if the user hasn't overridden it. Linux-only.
+    // On a virtualized GPU (VM, virgl/Venus) the WebKitWebProcess — the separate child that renders the page —
+    // can't create an EGL display for its accelerated compositor and hard-aborts ("Could not create default
+    // EGL display: EGL_BAD_PARAMETER. Aborting..."; confirmed via coredumpctl to be WebKitWebProcess, not our
+    // code). Disabling WebKitGTK's accelerated compositing makes the web process paint on the CPU and avoids
+    // that EGL display entirely. Only-if-unset so real-GPU users can re-enable. mpv's own GL surface is a
+    // separate concern in the main process.
+    // NOTE: do NOT also set WEBKIT_DISABLE_DMABUF_RENDERER — on Omarchy, compositing-off + DMABUF-off ABORTED,
+    // while compositing-off + DMABUF-on rendered fine. The DMABUF renderer is also the fast path on real HW.
+    // TODO(perf): compositing-off penalizes real-hardware Linux; gate on a virtualized-GPU probe before GA.
     #[cfg(target_os = "linux")]
-    if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
-        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    if std::env::var_os("WEBKIT_DISABLE_COMPOSITING_MODE").is_none() {
+        std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
     }
     tauri::Builder::default()
         // Log plugin first so it captures everything (Rust `log::*` + JS `@tauri-apps/plugin-log`)

--- a/apps/tv-tauri/src-tauri/src/lib.rs
+++ b/apps/tv-tauri/src-tauri/src/lib.rs
@@ -515,6 +515,9 @@ fn setup_player(app: &mut tauri::App) -> Result<(), String> {
     // Transparent webview so the video composites behind the UI (Windows: WebView2/DComp over the
     // child HWND; macOS: transparent WKWebView over the Metal layer). NOT window transparency on
     // Windows; on macOS the window itself is transparent (tauri.macos.conf `transparent: true`).
+    // Linux EXCLUDED: soia sets this Windows-only; forcing a transparent bg on WebKitGTK here can blank
+    // the UI. Linux transparency comes from tauri.linux.conf (`transparent: true`).
+    #[cfg(not(target_os = "linux"))]
     let _ = window.set_background_color(Some(tauri::utils::config::Color(0, 0, 0, 0)));
 
     // macOS: extend the webview content under a transparent titlebar so the NATIVE traffic lights
@@ -548,9 +551,15 @@ fn setup_player(app: &mut tauri::App) -> Result<(), String> {
     }
     #[cfg(target_os = "linux")]
     {
-        mpv.set_option_string("vo", "libmpv")?; // enable the render API (GLArea render context)
+        mpv.set_option_string("vo", "libmpv")?; // enable the render API
         mpv.initialize()?;
-        render_linux::setup(&window, &mpv)?;
+        // DIAGNOSTIC (temporary): the GtkOverlay reparent in render_linux::setup blanks the WebKitGTK
+        // webview. Skip it to confirm the UI renders when the webview is left untouched. If it does, the
+        // reparent is the cause → build the no-reparent wl_subsurface + EGL path (soia's model). Then
+        // restore this call. See .plans/tv-tauri-linux-render.md.
+        let _ = &window;
+        log::warn!("linux video: DIAGNOSTIC — video setup skipped, webview left untouched");
+        // render_linux::setup(&window, &mpv)?;
     }
     #[cfg(target_os = "windows")]
     {

--- a/apps/tv-tauri/src-tauri/src/lib.rs
+++ b/apps/tv-tauri/src-tauri/src/lib.rs
@@ -450,6 +450,14 @@ fn local_subnets() -> Vec<String> {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // WebKitGTK 2.42+ uses a DMABUF GPU renderer that draws a BLANK window on many drivers and especially
+    // virtualized GPUs (VMs) — the classic "Tauri Linux blank window." Disable it before the webview inits
+    // so the UI paints via the fallback path. Our mpv video uses its own GL context and is unaffected. Set
+    // only if the user hasn't overridden it. Linux-only.
+    #[cfg(target_os = "linux")]
+    if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
     tauri::Builder::default()
         // Log plugin first so it captures everything (Rust `log::*` + JS `@tauri-apps/plugin-log`)
         // to the terminal running `tauri dev`. Registered unconditionally so JS logging works.

--- a/apps/tv-tauri/src-tauri/src/lib.rs
+++ b/apps/tv-tauri/src-tauri/src/lib.rs
@@ -448,53 +448,8 @@ fn local_subnets() -> Vec<String> {
     prefixes
 }
 
-/// On a virtualized GPU (VM, virgl/Venus) WebKitGTK's WebProcess can't create an EGL display for its
-/// accelerated compositor and hard-aborts ("Could not create default EGL display: EGL_BAD_PARAMETER.
-/// Aborting...") before any window shows — confirmed via coredumpctl to be WebKitWebProcess, unrelated to our
-/// video code (a blank window aborts the same way). Disabling accelerated compositing (webview paints on the
-/// CPU, which is fine — mpv owns video on its own GL path) avoids that EGL display and fixes it.
-///
-/// The catch: WebKit reads `WEBKIT_DISABLE_COMPOSITING_MODE` when libwebkit2gtk LOADS, before `main` runs, so
-/// setting it in-process is too late (verified on-device: it only takes effect when present at process start,
-/// e.g. from the shell). So if it isn't already set, set it and re-exec ourselves — the fresh process starts
-/// with it in the environment before WebKit loads. Guarded against an exec loop; opt out on real GPUs with
-/// `AIRWAVE_NO_WEBKIT_REEXEC=1`. TODO(perf): gate the default on a virtualized-GPU probe before GA.
-#[cfg(target_os = "linux")]
-fn ensure_webkit_env_via_reexec() {
-    use std::ffi::CString;
-    use std::os::unix::ffi::OsStrExt;
-
-    if std::env::var_os("WEBKIT_DISABLE_COMPOSITING_MODE").is_some()
-        || std::env::var_os("AIRWAVE_NO_WEBKIT_REEXEC").is_some()
-    {
-        return; // already set by the user/shell, or we've already re-exec'd once.
-    }
-    let Ok(exe) = std::env::current_exe() else {
-        return;
-    };
-    let Ok(exe_c) = CString::new(exe.as_os_str().as_bytes()) else {
-        return;
-    };
-    let argv_c: Vec<CString> = std::env::args_os()
-        .filter_map(|a| CString::new(a.as_bytes()).ok())
-        .collect();
-    std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
-    std::env::set_var("AIRWAVE_NO_WEBKIT_REEXEC", "1"); // loop guard for the re-exec'd process
-    let mut argv: Vec<*const libc::c_char> = argv_c.iter().map(|a| a.as_ptr()).collect();
-    argv.push(std::ptr::null());
-    // SAFETY: exe_c/argv are valid, NUL-terminated C strings that outlive the call; execv replaces this
-    // process image and only returns on failure.
-    unsafe {
-        libc::execv(exe_c.as_ptr(), argv.as_ptr());
-    }
-    log::error!("re-exec to set WEBKIT_DISABLE_COMPOSITING_MODE failed; continuing (may abort in a VM)");
-}
-
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    // Must run before WebKit's library loads (see the function doc). Linux/VM-only workaround.
-    #[cfg(target_os = "linux")]
-    ensure_webkit_env_via_reexec();
     tauri::Builder::default()
         // Log plugin first so it captures everything (Rust `log::*` + JS `@tauri-apps/plugin-log`)
         // to the terminal running `tauri dev`. Registered unconditionally so JS logging works.

--- a/apps/tv-tauri/src-tauri/src/mpv/ffi.rs
+++ b/apps/tv-tauri/src-tauri/src/mpv/ffi.rs
@@ -156,6 +156,8 @@ pub const MPV_RENDER_PARAM_API_TYPE: c_int = 1;
 pub const MPV_RENDER_PARAM_OPENGL_INIT_PARAMS: c_int = 2;
 pub const MPV_RENDER_PARAM_OPENGL_FBO: c_int = 3;
 pub const MPV_RENDER_PARAM_FLIP_Y: c_int = 4;
+pub const MPV_RENDER_PARAM_X11_DISPLAY: c_int = 8; // Linux VAAPI hint (not output)
+pub const MPV_RENDER_PARAM_WL_DISPLAY: c_int = 9; // Linux VAAPI hint (not output)
 pub const MPV_RENDER_PARAM_ADVANCED_CONTROL: c_int = 10;
 
 /// `MPV_RENDER_API_TYPE_OPENGL` string value for the API_TYPE param.

--- a/apps/tv-tauri/src-tauri/src/mpv/mod.rs
+++ b/apps/tv-tauri/src-tauri/src/mpv/mod.rs
@@ -69,7 +69,7 @@ impl Mpv {
 
     /// The raw mpv context pointer (for `mpv_render_context_create` on macOS). The render context is
     /// created once at setup and lives for the app; the caller must not free the ctx.
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     pub fn ctx_raw(&self) -> *mut c_void {
         self.ctx()
     }

--- a/apps/tv-tauri/src-tauri/src/mpv/mod.rs
+++ b/apps/tv-tauri/src-tauri/src/mpv/mod.rs
@@ -35,6 +35,15 @@ impl Mpv {
     /// Call [`Mpv::set_option_string`] for pre-init options BEFORE this if
     /// needed; here we set them then `mpv_initialize`.
     pub fn new() -> Result<Self, String> {
+        // mpv REQUIRES the C numeric locale before mpv_create(), or it refuses to initialize
+        // ("Non-C locale detected... mpv_create() returned null"). glibc desktops and the AppImage
+        // runtime commonly set a non-C LC_NUMERIC, which is what bit us on Omarchy. Force it here,
+        // before creating the context (plezy does the same: mpv_player.cc:35). Linux-gated:
+        // Windows/macOS create mpv fine as-is, so we leave the shipping platforms untouched.
+        #[cfg(target_os = "linux")]
+        unsafe {
+            libc::setlocale(libc::LC_NUMERIC, b"C\0".as_ptr() as *const libc::c_char);
+        }
         let ctx = unsafe { ffi::mpv_create() };
         if ctx.is_null() {
             return Err("mpv_create() returned null (libmpv missing or LC_NUMERIC not C)".into());

--- a/apps/tv-tauri/src-tauri/src/render_linux.rs
+++ b/apps/tv-tauri/src-tauri/src/render_linux.rs
@@ -23,23 +23,29 @@ use gtk::prelude::*;
 
 use crate::mpv::{self, ffi};
 
-// ── GL proc resolution (libepoxy directly) ───────────────────────────────────
-// GTK links libepoxy; we dlopen it and use `epoxy_get_proc_address` to resolve GL symbols for mpv and for
-// our own glGetIntegerv. (We do NOT use the `epoxy` crate — its 0.1.0 pins a gl_generator that depends on a
-// yanked xml-rs and won't build.)
-type EpoxyGetProc = unsafe extern "C" fn(*const c_char) -> *mut c_void;
-static EPOXY_GET_PROC: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
+// ── GL proc resolution (eglGetProcAddress) ───────────────────────────────────
+// GDK creates an EGL context on Wayland/X11, so we resolve every GL/EGL symbol mpv needs (and our own
+// glGetIntegerv) through the driver's `eglGetProcAddress` — exactly like plezy (mpv_player.cc:20). We
+// dlopen `libEGL.so.1` (the SYSTEM driver's EGL, never a bundled copy — linuxdeploy excludes libEGL for
+// this reason) and cache `eglGetProcAddress`. This replaces an earlier attempt to use libepoxy, which does
+// NOT export a generic `epoxy_get_proc_address` (undefined-symbol crash).
+type EglGetProc = unsafe extern "C" fn(*const c_char) -> *mut c_void;
+static EGL_GET_PROC: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
 
 fn resolve(name: *const c_char) -> *mut c_void {
-    let p = EPOXY_GET_PROC.load(Ordering::Relaxed);
+    let p = EGL_GET_PROC.load(Ordering::Relaxed);
     if p.is_null() {
         return ptr::null_mut();
     }
-    let f: EpoxyGetProc = unsafe { std::mem::transmute(p) };
+    let f: EglGetProc = unsafe { std::mem::transmute(p) };
     unsafe { f(name) }
 }
 
-// mpv resolves each GL symbol it needs through this (whatever context GDK created — EGL on Wayland).
+fn resolve_cstr(name: &[u8]) -> *mut c_void {
+    resolve(name.as_ptr() as *const c_char)
+}
+
+// mpv resolves each GL symbol it needs through this (whatever context GDK created — EGL on Wayland/X11).
 extern "C" fn get_proc_address(_ctx: *mut c_void, name: *const c_char) -> *mut c_void {
     resolve(name)
 }
@@ -54,11 +60,18 @@ static GL_GET_INTEGERV: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
 const GL_DRAW_FRAMEBUFFER_BINDING: c_int = 0x8CA6;
 
 fn current_fbo() -> c_int {
-    let f = GL_GET_INTEGERV.load(Ordering::Relaxed);
+    // Resolve lazily on first use: eglGetProcAddress most reliably returns core-GL entry points once a
+    // context is current, which it is inside the GLArea `render` pass (our only caller).
+    let mut f = GL_GET_INTEGERV.load(Ordering::Relaxed);
+    if f.is_null() {
+        f = resolve_cstr(b"glGetIntegerv\0");
+        GL_GET_INTEGERV.store(f, Ordering::Relaxed);
+    }
     if f.is_null() {
         return 0;
     }
-    // SAFETY: `f` is `glGetIntegerv` resolved via epoxy; called on the GTK render (main) thread.
+    // SAFETY: `f` is `glGetIntegerv` resolved via eglGetProcAddress; called on the GTK render (main) thread
+    // with the GLArea's GL context current.
     let get: GlGetIntegerv = unsafe { std::mem::transmute(f) };
     let mut fbo: c_int = 0;
     get(GL_DRAW_FRAMEBUFFER_BINDING, &mut fbo);
@@ -118,16 +131,20 @@ extern "C" fn on_update(data: *mut c_void) {
 /// Insert a GLArea behind the transparent webview, create mpv's OpenGL render context, and wire the render
 /// pump. Call AFTER `mpv_initialize` (with `vo=libmpv`), on the main thread (Tauri `setup`).
 pub fn setup(window: &tauri::WebviewWindow, mpv: &Arc<mpv::Mpv>) -> Result<(), String> {
-    // Resolve GL procs via libepoxy (already linked by GTK). Cache `epoxy_get_proc_address`, then use it
-    // for glGetIntegerv (the FBO read). The library handle is leaked for the app lifetime.
+    // Resolve GL procs via the driver's EGL. dlopen the SYSTEM libEGL (never a bundled copy) and cache
+    // `eglGetProcAddress`; `resolve()` then serves both mpv's proc callback and our glGetIntegerv. The
+    // handle is leaked for the app lifetime. (glGetIntegerv itself is resolved lazily in current_fbo once
+    // the GL context is current.)
     {
         use libloading::os::unix::{Library, Symbol};
-        let lib = unsafe { Library::new("libepoxy.so.0").or_else(|_| Library::new("libepoxy.so")) }
-            .map_err(|e| e.to_string())?;
-        let get: Symbol<EpoxyGetProc> = unsafe { lib.get(b"epoxy_get_proc_address").map_err(|e| e.to_string())? };
-        EPOXY_GET_PROC.store(*get as usize as *mut c_void, Ordering::Relaxed);
+        let lib = unsafe { Library::new("libEGL.so.1").or_else(|_| Library::new("libEGL.so")) }
+            .map_err(|e| format!("dlopen libEGL: {e}"))?;
+        let get: Symbol<EglGetProc> = unsafe {
+            lib.get(b"eglGetProcAddress")
+                .map_err(|e| format!("eglGetProcAddress: {e}"))?
+        };
+        EGL_GET_PROC.store(*get as usize as *mut c_void, Ordering::Relaxed);
         std::mem::forget(lib);
-        GL_GET_INTEGERV.store(resolve(b"glGetIntegerv\0".as_ptr() as *const c_char), Ordering::Relaxed);
     }
 
     let gtk_window = window.gtk_window().map_err(|e| e.to_string())?;

--- a/apps/tv-tauri/src-tauri/src/render_linux.rs
+++ b/apps/tv-tauri/src-tauri/src/render_linux.rs
@@ -148,8 +148,14 @@ pub fn setup(window: &tauri::WebviewWindow, mpv: &Arc<mpv::Mpv>) -> Result<(), S
     gl_area.set_has_depth_buffer(false);
     gl_area.set_has_stencil_buffer(false);
     overlay.add(&gl_area); // base layer (video)
-    overlay.add_overlay(&child); // the webview, on top
-    overlay.set_overlay_pass_through(&child, false);
+    // The webview goes on top as an overlay child. Overlay children take their natural size + alignment by
+    // default (so WebKitGTK collapses → blank window); force it to FILL the whole overlay so the UI shows.
+    child.set_halign(gtk::Align::Fill);
+    child.set_valign(gtk::Align::Fill);
+    child.set_hexpand(true);
+    child.set_vexpand(true);
+    overlay.add_overlay(&child); // the webview, on top (transparent, so the video shows through)
+    overlay.set_overlay_pass_through(&child, false); // the webview still receives input
     gtk_window.add(&overlay);
     overlay.show_all();
 

--- a/apps/tv-tauri/src-tauri/src/render_linux.rs
+++ b/apps/tv-tauri/src-tauri/src/render_linux.rs
@@ -13,7 +13,6 @@
 //! iteration (Omarchy/Hyprland/Wayland). Two risk points are flagged inline: (1) reparenting Tauri's GTK
 //! child into a GtkOverlay, and (2) reading the GLArea's bound FBO id. See `.plans/tv-tauri-linux-render.md`.
 
-use std::ffi::CStr;
 use std::os::raw::{c_char, c_int, c_void};
 use std::ptr;
 use std::sync::atomic::{AtomicPtr, Ordering};
@@ -24,14 +23,25 @@ use gtk::prelude::*;
 
 use crate::mpv::{self, ffi};
 
-// ── GL proc resolution (epoxy) ───────────────────────────────────────────────
-// mpv resolves each GL symbol it needs through this. GTK links libepoxy, so its loader hands back the
-// live GL/GLES entry points for whatever context GDK created (EGL on Wayland).
-extern "C" fn get_proc_address(_ctx: *mut c_void, name: *const c_char) -> *mut c_void {
-    let Ok(s) = (unsafe { CStr::from_ptr(name) }).to_str() else {
+// ── GL proc resolution (libepoxy directly) ───────────────────────────────────
+// GTK links libepoxy; we dlopen it and use `epoxy_get_proc_address` to resolve GL symbols for mpv and for
+// our own glGetIntegerv. (We do NOT use the `epoxy` crate — its 0.1.0 pins a gl_generator that depends on a
+// yanked xml-rs and won't build.)
+type EpoxyGetProc = unsafe extern "C" fn(*const c_char) -> *mut c_void;
+static EPOXY_GET_PROC: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
+
+fn resolve(name: *const c_char) -> *mut c_void {
+    let p = EPOXY_GET_PROC.load(Ordering::Relaxed);
+    if p.is_null() {
         return ptr::null_mut();
-    };
-    epoxy::get_proc_addr(s) as *mut c_void
+    }
+    let f: EpoxyGetProc = unsafe { std::mem::transmute(p) };
+    unsafe { f(name) }
+}
+
+// mpv resolves each GL symbol it needs through this (whatever context GDK created — EGL on Wayland).
+extern "C" fn get_proc_address(_ctx: *mut c_void, name: *const c_char) -> *mut c_void {
+    resolve(name)
 }
 
 // The live mpv render context, so the GLArea's `render` closure (main thread) can draw with it. Only ever
@@ -108,19 +118,17 @@ extern "C" fn on_update(data: *mut c_void) {
 /// Insert a GLArea behind the transparent webview, create mpv's OpenGL render context, and wire the render
 /// pump. Call AFTER `mpv_initialize` (with `vo=libmpv`), on the main thread (Tauri `setup`).
 pub fn setup(window: &tauri::WebviewWindow, mpv: &Arc<mpv::Mpv>) -> Result<(), String> {
-    // Load libepoxy so both mpv's get_proc_address and our glGetIntegerv resolve to the live GL entry
-    // points. GTK already links epoxy; we just point the crate's loader at it.
+    // Resolve GL procs via libepoxy (already linked by GTK). Cache `epoxy_get_proc_address`, then use it
+    // for glGetIntegerv (the FBO read). The library handle is leaked for the app lifetime.
     {
-        use libloading::os::unix::Library;
-        // RTLD_DEFAULT-style: epoxy is already in-process (GTK linked it); open with the SONAME.
-        let lib = Library::new("libepoxy.so.0").or_else(|_| Library::new("libepoxy.so")).map_err(|e| e.to_string())?;
-        epoxy::load_with(|name| unsafe {
-            lib.get::<*const c_void>(name.as_bytes()).map(|s| *s).unwrap_or(ptr::null())
-        });
-        // Cache glGetIntegerv for the FBO read.
-        GL_GET_INTEGERV.store(epoxy::get_proc_addr("glGetIntegerv") as *mut c_void, Ordering::Relaxed);
-        // Leak the library handle for the app lifetime.
+        use libloading::os::unix::{Library, Symbol};
+        let lib = Library::new("libepoxy.so.0")
+            .or_else(|_| Library::new("libepoxy.so"))
+            .map_err(|e| e.to_string())?;
+        let get: Symbol<EpoxyGetProc> = unsafe { lib.get(b"epoxy_get_proc_address").map_err(|e| e.to_string())? };
+        EPOXY_GET_PROC.store(*get as usize as *mut c_void, Ordering::Relaxed);
         std::mem::forget(lib);
+        GL_GET_INTEGERV.store(resolve(b"glGetIntegerv\0".as_ptr() as *const c_char), Ordering::Relaxed);
     }
 
     let gtk_window = window.gtk_window().map_err(|e| e.to_string())?;

--- a/apps/tv-tauri/src-tauri/src/render_linux.rs
+++ b/apps/tv-tauri/src-tauri/src/render_linux.rs
@@ -1,104 +1,168 @@
-//! Linux video embedding via mpv's **render API** (soia's architecture; plezy's open GL recipe),
-//! mirroring `render_macos.rs`.
+//! Linux video via mpv's **render API** into a Wayland **subsurface** placed BEHIND the transparent
+//! WebKitGTK webview — soia's proven architecture, with NO GTK widget reparenting.
 //!
-//! Like macOS — and UNLIKE Windows — we do NOT hand mpv a `wid`. mpv never owns a window here. Instead
-//! we run `vo=libmpv`, insert a GTK `GLArea` BEHIND the transparent WebKitGTK webview (via a `GtkOverlay`),
-//! create an `mpv_render_context` (OpenGL), and render each mpv frame into the GLArea's framebuffer. GTK/GDK
-//! owns the actual GL (EGL) context, so this is windowing-agnostic and works on Wayland natively (and under
-//! XWayland). The Wayland/X11 *display* handle is passed to the render context ONLY for VAAPI hw-decode, not
-//! for output.
+//! Why not a GtkGLArea: inserting a GLArea means wrapping Tauri's webview in a container (GtkOverlay), which
+//! reparents the webview — that panics Tauri's undecorated-resizing handler and blanks the UI. soia never
+//! touches GTK widgets; it drops to raw Wayland: take the toplevel's `wl_surface` + `wl_display`, create a
+//! `wl_subsurface` as a child placed *below* the parent, give it its own EGL window surface, and render mpv
+//! into it. The webview (parent surface) stays untouched and composites over the video via its transparent
+//! regions.
 //!
-//! ⚠️ UNVALIDATED on hardware. The mpv-render half is a direct translation of plezy
-//! (`.refs/plezy/linux/runner/mpv/`); the GLArea-behind-webview compositing is the part that needs on-device
-//! iteration (Omarchy/Hyprland/Wayland). Two risk points are flagged inline: (1) reparenting Tauri's GTK
-//! child into a GtkOverlay, and (2) reading the GLArea's bound FBO id. See `.plans/tv-tauri-linux-render.md`.
+//! Pipeline: raw-window-handle → (`wl_surface`, `wl_display`) → bind `wl_compositor`/`wl_subcompositor`
+//! (wayland-client, own event queue) → child `wl_surface` + `wl_subsurface` (place_below + desync) →
+//! `wl_egl_window` (wayland-egl) → `eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND)` + config + context +
+//! window surface → `mpv_render_context` (OpenGL, proc addr = `eglGetProcAddress`). Frames pump on mpv's
+//! update-callback, bounced to the GTK main loop (glib channel), rendered into FBO 0 + `eglSwapBuffers`.
+//!
+//! ⚠️ UNVALIDATED end-to-end on hardware; iterate on Omarchy. Any failure here logs and leaves the (working)
+//! UI intact — video is best-effort.
 
 use std::os::raw::{c_char, c_int, c_void};
 use std::ptr;
-use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::atomic::{AtomicI32, AtomicPtr, Ordering};
 use std::sync::Arc;
 
-use gtk::glib::translate::ToGlibPtr;
-use gtk::prelude::*;
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawDisplayHandle, RawWindowHandle};
+use wayland_client::backend::{Backend, ObjectId};
+use wayland_client::globals::{registry_queue_init, GlobalListContents};
+use wayland_client::protocol::{
+    wl_compositor::WlCompositor, wl_registry::WlRegistry, wl_subcompositor::WlSubcompositor,
+    wl_subsurface::WlSubsurface, wl_surface::WlSurface,
+};
+use wayland_client::{Connection, Dispatch, Proxy, QueueHandle};
+use wayland_egl::WlEglSurface;
 
 use crate::mpv::{self, ffi};
 
-// ── GL proc resolution (eglGetProcAddress) ───────────────────────────────────
-// GDK creates an EGL context on Wayland/X11, so we resolve every GL/EGL symbol mpv needs (and our own
-// glGetIntegerv) through the driver's `eglGetProcAddress` — exactly like plezy (mpv_player.cc:20). We
-// dlopen `libEGL.so.1` (the SYSTEM driver's EGL, never a bundled copy — linuxdeploy excludes libEGL for
-// this reason) and cache `eglGetProcAddress`. This replaces an earlier attempt to use libepoxy, which does
-// NOT export a generic `epoxy_get_proc_address` (undefined-symbol crash).
-type EglGetProc = unsafe extern "C" fn(*const c_char) -> *mut c_void;
-static EGL_GET_PROC: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
+// ── EGL (host libEGL; never bundled — see the gtk-plugin exclude list) ────────
+#[allow(non_camel_case_types)]
+type EGLDisplay = *mut c_void;
+#[allow(non_camel_case_types)]
+type EGLConfig = *mut c_void;
+#[allow(non_camel_case_types)]
+type EGLContext = *mut c_void;
+#[allow(non_camel_case_types)]
+type EGLSurface = *mut c_void;
 
-fn resolve(name: *const c_char) -> *mut c_void {
-    let p = EGL_GET_PROC.load(Ordering::Relaxed);
-    if p.is_null() {
-        return ptr::null_mut();
-    }
-    let f: EglGetProc = unsafe { std::mem::transmute(p) };
-    unsafe { f(name) }
+const EGL_PLATFORM_WAYLAND_KHR: u32 = 0x31D8;
+const EGL_OPENGL_API: u32 = 0x30A2;
+const EGL_NO_CONTEXT: EGLContext = ptr::null_mut();
+const EGL_NONE: isize = 0x3038;
+const EGL_SURFACE_TYPE: isize = 0x3033;
+const EGL_WINDOW_BIT: isize = 0x0004;
+const EGL_RENDERABLE_TYPE: isize = 0x3040;
+const EGL_OPENGL_BIT: isize = 0x0008;
+const EGL_RED_SIZE: isize = 0x3024;
+const EGL_GREEN_SIZE: isize = 0x3023;
+const EGL_BLUE_SIZE: isize = 0x3022;
+const EGL_ALPHA_SIZE: isize = 0x3021;
+const EGL_CONTEXT_MAJOR_VERSION: isize = 0x3098;
+
+#[link(name = "EGL")]
+extern "C" {
+    fn eglGetPlatformDisplay(
+        platform: u32,
+        native_display: *mut c_void,
+        attrib_list: *const isize,
+    ) -> EGLDisplay;
+    fn eglInitialize(dpy: EGLDisplay, major: *mut i32, minor: *mut i32) -> u32;
+    fn eglBindAPI(api: u32) -> u32;
+    fn eglChooseConfig(
+        dpy: EGLDisplay,
+        attribs: *const isize,
+        configs: *mut EGLConfig,
+        size: i32,
+        num: *mut i32,
+    ) -> u32;
+    fn eglCreateContext(
+        dpy: EGLDisplay,
+        config: EGLConfig,
+        share: EGLContext,
+        attribs: *const isize,
+    ) -> EGLContext;
+    fn eglCreateWindowSurface(
+        dpy: EGLDisplay,
+        config: EGLConfig,
+        win: *mut c_void,
+        attribs: *const isize,
+    ) -> EGLSurface;
+    fn eglMakeCurrent(dpy: EGLDisplay, draw: EGLSurface, read: EGLSurface, ctx: EGLContext) -> u32;
+    fn eglSwapBuffers(dpy: EGLDisplay, surface: EGLSurface) -> u32;
+    fn eglSwapInterval(dpy: EGLDisplay, interval: i32) -> u32;
+    fn eglGetError() -> i32;
+    fn eglGetProcAddress(name: *const c_char) -> *mut c_void;
 }
 
-fn resolve_cstr(name: &[u8]) -> *mut c_void {
-    resolve(name.as_ptr() as *const c_char)
-}
-
-// mpv resolves each GL symbol it needs through this (whatever context GDK created — EGL on Wayland/X11).
+// mpv resolves each GL symbol it needs through the driver's eglGetProcAddress (matches plezy).
 extern "C" fn get_proc_address(_ctx: *mut c_void, name: *const c_char) -> *mut c_void {
-    resolve(name)
+    unsafe { eglGetProcAddress(name) }
 }
 
-// The live mpv render context, so the GLArea's `render` closure (main thread) can draw with it. Only ever
-// touched on the GTK main thread after setup; stored as a raw pointer so the closures can capture it Copy.
+// Live render state, shared with the main-loop render handler. Raw pointers so the closure captures Copy.
 static RENDER_CTX: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
+static EGL_DISPLAY: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
+static EGL_SURFACE: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
+static EGL_CONTEXT: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
+static FB_W: AtomicI32 = AtomicI32::new(0);
+static FB_H: AtomicI32 = AtomicI32::new(0);
+// The wl_egl_window, kept alive + resized on window resize. Boxed WlEglSurface leaked to a raw ptr.
+static EGL_WINDOW: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
 
-/// Loaded once: `glGetIntegerv`, so we can read the FBO id GTK bound before calling our `render` closure.
-type GlGetIntegerv = extern "C" fn(pname: c_int, params: *mut c_int);
-static GL_GET_INTEGERV: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
-const GL_DRAW_FRAMEBUFFER_BINDING: c_int = 0x8CA6;
+// ── wayland-client dispatch (all events ignored; we only send requests) ───────
+struct State;
+impl Dispatch<WlRegistry, GlobalListContents> for State {
+    fn event(
+        _: &mut Self,
+        _: &WlRegistry,
+        _: wl_registry::Event,
+        _: &GlobalListContents,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+use wayland_client::protocol::wl_registry;
+macro_rules! ignore_events {
+    ($($iface:ty),+ $(,)?) => {$(
+        impl Dispatch<$iface, ()> for State {
+            fn event(
+                _: &mut Self,
+                _: &$iface,
+                _: <$iface as Proxy>::Event,
+                _: &(),
+                _: &Connection,
+                _: &QueueHandle<Self>,
+            ) {
+            }
+        }
+    )+};
+}
+ignore_events!(WlCompositor, WlSubcompositor, WlSurface, WlSubsurface);
 
-fn current_fbo() -> c_int {
-    // Resolve lazily on first use: eglGetProcAddress most reliably returns core-GL entry points once a
-    // context is current, which it is inside the GLArea `render` pass (our only caller).
-    let mut f = GL_GET_INTEGERV.load(Ordering::Relaxed);
-    if f.is_null() {
-        f = resolve_cstr(b"glGetIntegerv\0");
-        GL_GET_INTEGERV.store(f, Ordering::Relaxed);
-    }
-    if f.is_null() {
-        return 0;
-    }
-    // SAFETY: `f` is `glGetIntegerv` resolved via eglGetProcAddress; called on the GTK render (main) thread
-    // with the GLArea's GL context current.
-    let get: GlGetIntegerv = unsafe { std::mem::transmute(f) };
-    let mut fbo: c_int = 0;
-    get(GL_DRAW_FRAMEBUFFER_BINDING, &mut fbo);
-    fbo
+fn egl_err() -> i32 {
+    unsafe { eglGetError() }
 }
 
-/// Render one mpv frame into the framebuffer GTK bound for this `GLArea::render` pass. Runs on the GTK main
-/// thread inside the `render` signal.
-fn render(area: &gtk::GLArea) {
+/// Render one mpv frame into the EGL window surface's default framebuffer. GTK main thread.
+fn render() {
     let ctx = RENDER_CTX.load(Ordering::Acquire);
-    if ctx.is_null() {
+    let dpy = EGL_DISPLAY.load(Ordering::Acquire);
+    let surf = EGL_SURFACE.load(Ordering::Acquire);
+    let egl_ctx = EGL_CONTEXT.load(Ordering::Acquire);
+    if ctx.is_null() || dpy.is_null() || surf.is_null() || egl_ctx.is_null() {
         return;
     }
-    let scale = area.scale_factor().max(1);
-    let w = area.allocated_width() * scale;
-    let h = area.allocated_height() * scale;
-    if w <= 0 || h <= 0 {
+    if unsafe { eglMakeCurrent(dpy, surf, surf, egl_ctx) } == 0 {
+        log::error!("eglMakeCurrent (render) failed: 0x{:x}", egl_err());
         return;
     }
     let mut fbo = ffi::MpvOpenglFbo {
-        fbo: current_fbo(),
-        w,
-        h,
-        internal_format: 0, // SDR 8-bit for now; RGBA16F HDR passthrough is a later pass (see macOS).
+        fbo: 0, // the EGL window surface's default framebuffer
+        w: FB_W.load(Ordering::Relaxed),
+        h: FB_H.load(Ordering::Relaxed),
+        internal_format: 0,
     };
-    // GTK's GLArea framebuffer is already top-left origin like mpv expects, so no Y-flip (plezy uses 0 too).
-    let mut flip: c_int = 0;
+    let mut flip: c_int = 1; // on-screen GL surface: flip Y (macOS render path uses the same)
     let mut params = [
         ffi::MpvRenderParam {
             type_: ffi::MPV_RENDER_PARAM_OPENGL_FBO,
@@ -114,155 +178,195 @@ fn render(area: &gtk::GLArea) {
         },
     ];
     unsafe { ffi::mpv_render_context_render(ctx, params.as_mut_ptr()) };
+    unsafe {
+        if eglSwapBuffers(dpy, surf) == 0 {
+            log::error!("eglSwapBuffers failed: 0x{:x}", egl_err());
+        }
+    }
 }
 
-/// mpv's render-update callback — fires (possibly off the GTK thread) when a new frame is ready. We must
-/// NOT touch GTK from here; bounce to the main loop and `queue_render`. `data` is the leaked GLArea ptr's
-/// weak-ish handle via a channel sender (see setup). Kept minimal: it just wakes the main loop.
+/// mpv update-callback (any thread): wake the main loop to render. `data` is a leaked glib::Sender<()>.
 extern "C" fn on_update(data: *mut c_void) {
     if data.is_null() {
         return;
     }
-    // SAFETY: `data` is a leaked `glib::Sender<()>` living for the app lifetime.
     let tx = unsafe { &*(data as *const gtk::glib::Sender<()>) };
     let _ = tx.send(());
 }
 
-/// Insert a GLArea behind the transparent webview, create mpv's OpenGL render context, and wire the render
-/// pump. Call AFTER `mpv_initialize` (with `vo=libmpv`), on the main thread (Tauri `setup`).
+/// Set up the subsurface + EGL + mpv render context. Best-effort: errors are logged, never fatal (the UI
+/// keeps working without video). Call after `mpv_initialize` (with `vo=libmpv`), on the GTK main thread.
 pub fn setup(window: &tauri::WebviewWindow, mpv: &Arc<mpv::Mpv>) -> Result<(), String> {
-    // Resolve GL procs via the driver's EGL. dlopen the SYSTEM libEGL (never a bundled copy) and cache
-    // `eglGetProcAddress`; `resolve()` then serves both mpv's proc callback and our glGetIntegerv. The
-    // handle is leaked for the app lifetime. (glGetIntegerv itself is resolved lazily in current_fbo once
-    // the GL context is current.)
+    // 1. Raw Wayland handles from the toplevel window.
+    let display_ptr = match window.display_handle().map_err(|e| e.to_string())?.as_raw() {
+        RawDisplayHandle::Wayland(d) => d.display.as_ptr(),
+        other => return Err(format!("not a Wayland display: {other:?}")),
+    };
+    let parent_surface_ptr = match window.window_handle().map_err(|e| e.to_string())?.as_raw() {
+        RawWindowHandle::Wayland(w) => w.surface.as_ptr(),
+        other => return Err(format!("not a Wayland window: {other:?}")),
+    };
+
+    // 2. Wrap the foreign display; bind compositor + subcompositor via our own event queue (roundtrip).
+    let backend = unsafe { Backend::from_foreign_display(display_ptr as *mut _) };
+    let conn = Connection::from_backend(backend);
+    let (globals, event_queue) =
+        registry_queue_init::<State>(&conn).map_err(|e| format!("registry init: {e}"))?;
+    let qh = event_queue.handle();
+    let compositor: WlCompositor = globals
+        .bind(&qh, 1..=6, ())
+        .map_err(|e| format!("bind wl_compositor: {e}"))?;
+    let subcompositor: WlSubcompositor = globals
+        .bind(&qh, 1..=1, ())
+        .map_err(|e| format!("bind wl_subcompositor: {e}"))?;
+
+    // 3. Wrap the parent surface, create the child surface + subsurface (below the webview, desync).
+    let parent = unsafe {
+        WlSurface::from_id(
+            &conn,
+            ObjectId::from_ptr(WlSurface::interface(), parent_surface_ptr as *mut _)
+                .map_err(|e| format!("parent surface id: {e}"))?,
+        )
+        .map_err(|e| format!("parent surface proxy: {e}"))?
+    };
+    let child: WlSurface = compositor.create_surface(&qh, ());
+    let subsurface: WlSubsurface = subcompositor.get_subsurface(&child, &parent, &qh, ());
+    subsurface.set_position(0, 0);
+    subsurface.place_below(&parent); // video behind the transparent webview
+    subsurface.set_desync(); // child commits (eglSwapBuffers) apply without waiting on the parent
+
+    // 4. Size = the window's physical pixels.
+    let size = window.inner_size().map_err(|e| e.to_string())?;
+    let (w, h) = (size.width.max(1) as i32, size.height.max(1) as i32);
+    FB_W.store(w, Ordering::Relaxed);
+    FB_H.store(h, Ordering::Relaxed);
+
+    // 5. wl_egl_window on the child surface.
+    let egl_window =
+        WlEglSurface::new(child.id(), w, h).map_err(|e| format!("wl_egl_window: {e}"))?;
+    let egl_window_ptr = egl_window.ptr() as *mut c_void;
+
+    // 6. EGL: platform display, config, context, window surface.
+    let dpy = unsafe { eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_KHR, display_ptr as *mut _, ptr::null()) };
+    if dpy.is_null() {
+        return Err(format!("eglGetPlatformDisplay failed: 0x{:x}", egl_err()));
+    }
+    if unsafe { eglInitialize(dpy, ptr::null_mut(), ptr::null_mut()) } == 0 {
+        return Err(format!("eglInitialize failed: 0x{:x}", egl_err()));
+    }
+    if unsafe { eglBindAPI(EGL_OPENGL_API) } == 0 {
+        return Err(format!("eglBindAPI failed: 0x{:x}", egl_err()));
+    }
+    let cfg_attribs: [isize; 13] = [
+        EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
+        EGL_RED_SIZE, 8,
+        EGL_GREEN_SIZE, 8,
+        EGL_BLUE_SIZE, 8,
+        EGL_ALPHA_SIZE, 8,
+        EGL_NONE,
+    ];
+    let mut config: EGLConfig = ptr::null_mut();
+    let mut num_cfg: i32 = 0;
+    if unsafe { eglChooseConfig(dpy, cfg_attribs.as_ptr(), &mut config, 1, &mut num_cfg) } == 0
+        || num_cfg == 0
     {
-        use libloading::os::unix::{Library, Symbol};
-        let lib = unsafe { Library::new("libEGL.so.1").or_else(|_| Library::new("libEGL.so")) }
-            .map_err(|e| format!("dlopen libEGL: {e}"))?;
-        let get: Symbol<EglGetProc> = unsafe {
-            lib.get(b"eglGetProcAddress")
-                .map_err(|e| format!("eglGetProcAddress: {e}"))?
-        };
-        EGL_GET_PROC.store(*get as usize as *mut c_void, Ordering::Relaxed);
-        std::mem::forget(lib);
+        return Err(format!("eglChooseConfig failed: 0x{:x}", egl_err()));
+    }
+    let ctx_attribs: [isize; 3] = [EGL_CONTEXT_MAJOR_VERSION, 3, EGL_NONE];
+    let egl_ctx = unsafe { eglCreateContext(dpy, config, EGL_NO_CONTEXT, ctx_attribs.as_ptr()) };
+    if egl_ctx.is_null() {
+        return Err(format!("eglCreateContext failed: 0x{:x}", egl_err()));
+    }
+    let egl_surf =
+        unsafe { eglCreateWindowSurface(dpy, config, egl_window_ptr, ptr::null()) };
+    if egl_surf.is_null() {
+        return Err(format!("eglCreateWindowSurface failed: 0x{:x}", egl_err()));
+    }
+    if unsafe { eglMakeCurrent(dpy, egl_surf, egl_surf, egl_ctx) } == 0 {
+        return Err(format!("eglMakeCurrent (setup) failed: 0x{:x}", egl_err()));
+    }
+    unsafe { eglSwapInterval(dpy, 0) }; // don't block the GTK main loop on vsync
+
+    // 7. mpv render context (GL context is current now).
+    let mut init = ffi::MpvOpenglInitParams {
+        get_proc_address,
+        get_proc_address_ctx: ptr::null_mut(),
+    };
+    let mut wl = display_ptr as *mut c_void;
+    let mut params = [
+        ffi::MpvRenderParam {
+            type_: ffi::MPV_RENDER_PARAM_API_TYPE,
+            data: ffi::MPV_RENDER_API_TYPE_OPENGL.as_ptr() as *mut c_void,
+        },
+        ffi::MpvRenderParam {
+            type_: ffi::MPV_RENDER_PARAM_OPENGL_INIT_PARAMS,
+            data: &mut init as *mut _ as *mut c_void,
+        },
+        // VAAPI hw-decode hint only (not output).
+        ffi::MpvRenderParam {
+            type_: ffi::MPV_RENDER_PARAM_WL_DISPLAY,
+            data: &mut wl as *mut _ as *mut c_void,
+        },
+        ffi::MpvRenderParam {
+            type_: ffi::MPV_RENDER_PARAM_INVALID,
+            data: ptr::null_mut(),
+        },
+    ];
+    let mut render_ctx: *mut c_void = ptr::null_mut();
+    let rc =
+        unsafe { ffi::mpv_render_context_create(&mut render_ctx, mpv.ctx_raw(), params.as_mut_ptr()) };
+    if rc < 0 || render_ctx.is_null() {
+        return Err(format!("mpv_render_context_create failed: {rc}"));
     }
 
-    let gtk_window = window.gtk_window().map_err(|e| e.to_string())?;
+    // Publish state for the render handler + resize hook.
+    EGL_DISPLAY.store(dpy, Ordering::Release);
+    EGL_CONTEXT.store(egl_ctx, Ordering::Release);
+    EGL_SURFACE.store(egl_surf, Ordering::Release);
+    EGL_WINDOW.store(Box::into_raw(Box::new(egl_window)) as *mut c_void, Ordering::Release);
+    RENDER_CTX.store(render_ctx, Ordering::Release);
 
-    // ⚠️ RISK 1 — compositing: Tauri's GTK window holds the WebKitGTK webview as its child. We move that
-    // child into a GtkOverlay with a GLArea as the overlay's BASE (so the video is behind) and the webview
-    // as the overlay child (transparent, so the HTML player composites over the video). The draft PR warned
-    // that wrapper-widget reparenting can trigger an undecorated-resize panic; if so, the fallback is a
-    // wl_subsurface below the webview (soia's model) instead of a GTK overlay. Validate on device.
-    let child = gtk_window.child().ok_or("Tauri GTK window has no child to reparent")?;
-    gtk_window.remove(&child);
-    let overlay = gtk::Overlay::new();
-    let gl_area = gtk::GLArea::new();
-    gl_area.set_hexpand(true);
-    gl_area.set_vexpand(true);
-    // mpv gpu/gpu-next want a modern context; GLArea defaults to desktop GL 3.2+ where available. Leave the
-    // GDK default (do not force ES) so we get the best context the compositor offers.
-    gl_area.set_has_depth_buffer(false);
-    gl_area.set_has_stencil_buffer(false);
-    overlay.add(&gl_area); // base layer (video)
-    // The webview goes on top as an overlay child. Overlay children take their natural size + alignment by
-    // default (so WebKitGTK collapses → blank window); force it to FILL the whole overlay so the UI shows.
-    child.set_halign(gtk::Align::Fill);
-    child.set_valign(gtk::Align::Fill);
-    child.set_hexpand(true);
-    child.set_vexpand(true);
-    overlay.add_overlay(&child); // the webview, on top (transparent, so the video shows through)
-    overlay.set_overlay_pass_through(&child, false); // the webview still receives input
-    gtk_window.add(&overlay);
-    overlay.show_all();
-
-    // A main-thread channel: mpv's update callback (any thread) sends; the receiver queues a GLArea redraw.
+    // 8. Pump: mpv update-callback (any thread) → glib channel → render on the main loop.
     let (tx, rx) = gtk::glib::MainContext::channel::<()>(gtk::glib::Priority::default());
-    {
-        let area = gl_area.clone();
-        rx.attach(None, move |_| {
-            area.queue_render();
-            gtk::glib::ControlFlow::Continue
-        });
-    }
-    // Leak the sender so its pointer stays valid for the update callback for the app lifetime.
+    rx.attach(None, move |_| {
+        render();
+        gtk::glib::ControlFlow::Continue
+    });
     let tx_ptr = Box::into_raw(Box::new(tx)) as *mut c_void;
+    unsafe { ffi::mpv_render_context_set_update_callback(render_ctx, on_update, tx_ptr) };
 
-    // Create the mpv render context when the GLArea's GL context is realized (GL must be current). Capture
-    // the mpv ctx handle + display handles for VAAPI.
-    let mpv_ctx = mpv.ctx_raw();
-    let wl_display = wayland_display_ptr(&gtk_window);
-    let x11_display = x11_display_ptr(&gtk_window);
-    gl_area.connect_realize(move |area| {
-        area.make_current();
-        if let Some(e) = area.error() {
-            log::error!("GLArea realize error: {e}");
-            return;
-        }
-        let mut init = ffi::MpvOpenglInitParams {
-            get_proc_address,
-            get_proc_address_ctx: ptr::null_mut(),
-        };
-        let mut params = vec![
-            ffi::MpvRenderParam {
-                type_: ffi::MPV_RENDER_PARAM_API_TYPE,
-                data: ffi::MPV_RENDER_API_TYPE_OPENGL.as_ptr() as *mut c_void,
-            },
-            ffi::MpvRenderParam {
-                type_: ffi::MPV_RENDER_PARAM_OPENGL_INIT_PARAMS,
-                data: &mut init as *mut _ as *mut c_void,
-            },
-        ];
-        // Display handle for VAAPI hw-decode only (NOT output). Prefer Wayland, else X11.
-        let mut wl = wl_display;
-        let mut x11 = x11_display;
-        if !wl.is_null() {
-            params.push(ffi::MpvRenderParam { type_: ffi::MPV_RENDER_PARAM_WL_DISPLAY, data: &mut wl as *mut _ as *mut c_void });
-        } else if !x11.is_null() {
-            params.push(ffi::MpvRenderParam { type_: ffi::MPV_RENDER_PARAM_X11_DISPLAY, data: &mut x11 as *mut _ as *mut c_void });
-        }
-        params.push(ffi::MpvRenderParam { type_: ffi::MPV_RENDER_PARAM_INVALID, data: ptr::null_mut() });
+    // Flush the queued subsurface requests to the compositor (placement applies on the parent's next
+    // commit, which GTK issues as it renders the webview; the child's first buffer arrives via
+    // eglSwapBuffers on the first render).
+    let _ = conn.flush();
 
-        let mut ctx: *mut c_void = ptr::null_mut();
-        let rc = unsafe { ffi::mpv_render_context_create(&mut ctx, mpv_ctx, params.as_mut_ptr()) };
-        if rc < 0 || ctx.is_null() {
-            log::error!("mpv_render_context_create failed: {rc}");
-            return;
-        }
-        RENDER_CTX.store(ctx, Ordering::Release);
-        unsafe { ffi::mpv_render_context_set_update_callback(ctx, on_update, tx_ptr) };
-        log::info!("Linux render context up (GLArea)");
-    });
+    // Keep the wayland objects + connection alive for the app lifetime (subsurface must not be dropped).
+    std::mem::forget(conn);
+    std::mem::forget(event_queue);
+    std::mem::forget(globals);
+    std::mem::forget(compositor);
+    std::mem::forget(subcompositor);
+    std::mem::forget(parent);
+    std::mem::forget(child);
+    std::mem::forget(subsurface);
 
-    gl_area.connect_render(move |area, _ctx| {
-        render(area);
-        gtk::glib::Propagation::Stop
-    });
-
+    log::info!("linux video: subsurface + EGL render context up ({w}x{h})");
     Ok(())
 }
 
-/// Best-effort resize hook. GLArea reallocates its own framebuffer on size/scale changes and re-renders,
-/// and our `render()` reads the live allocation each pass — so there's nothing mpv-side to do. Kept for
-/// symmetry with `render_macos::on_resize` and in case a future path needs an explicit refit.
-pub fn on_resize(_window: &tauri::WebviewWindow) {}
-
-// ── Display-handle extraction (VAAPI only) ───────────────────────────────────
-// Pull the raw `wl_display` / X11 `Display*` from the GTK window's GDK display, so mpv's VAAPI decoder can
-// reach the GPU. Returns null when the other backend is in use. These use gdk backend downcasts guarded so
-// a mismatched session just yields null (mpv then decodes without that VAAPI hint).
-fn wayland_display_ptr(gtk_window: &gtk::ApplicationWindow) -> *mut c_void {
-    let Some(display) = gtk_window.display().dynamic_cast_ref::<gdkwayland::WaylandDisplay>().cloned() else {
-        return ptr::null_mut();
+/// Resize the EGL window (and remembered FBO size) when the window resizes. GTK main thread.
+pub fn on_resize(window: &tauri::WebviewWindow) {
+    let Ok(size) = window.inner_size() else {
+        return;
     };
-    // SAFETY: FFI to gdk_wayland_display_get_wl_display on a confirmed Wayland display.
-    unsafe { gdkwayland::ffi::gdk_wayland_display_get_wl_display(display.to_glib_none().0) as *mut c_void }
-}
-
-fn x11_display_ptr(gtk_window: &gtk::ApplicationWindow) -> *mut c_void {
-    let Some(display) = gtk_window.display().dynamic_cast_ref::<gdkx11::X11Display>().cloned() else {
-        return ptr::null_mut();
-    };
-    // SAFETY: FFI to gdk_x11_display_get_xdisplay on a confirmed X11 display.
-    unsafe { gdkx11::ffi::gdk_x11_display_get_xdisplay(display.to_glib_none().0) as *mut c_void }
+    let (w, h) = (size.width.max(1) as i32, size.height.max(1) as i32);
+    FB_W.store(w, Ordering::Relaxed);
+    FB_H.store(h, Ordering::Relaxed);
+    let win = EGL_WINDOW.load(Ordering::Acquire);
+    if !win.is_null() {
+        // SAFETY: win is our leaked WlEglSurface for the app lifetime; resize is main-thread only.
+        let egl_window = unsafe { &*(win as *const WlEglSurface) };
+        egl_window.resize(w, h, 0, 0);
+    }
 }

--- a/apps/tv-tauri/src-tauri/src/render_linux.rs
+++ b/apps/tv-tauri/src-tauri/src/render_linux.rs
@@ -122,8 +122,7 @@ pub fn setup(window: &tauri::WebviewWindow, mpv: &Arc<mpv::Mpv>) -> Result<(), S
     // for glGetIntegerv (the FBO read). The library handle is leaked for the app lifetime.
     {
         use libloading::os::unix::{Library, Symbol};
-        let lib = Library::new("libepoxy.so.0")
-            .or_else(|_| Library::new("libepoxy.so"))
+        let lib = unsafe { Library::new("libepoxy.so.0").or_else(|_| Library::new("libepoxy.so")) }
             .map_err(|e| e.to_string())?;
         let get: Symbol<EpoxyGetProc> = unsafe { lib.get(b"epoxy_get_proc_address").map_err(|e| e.to_string())? };
         EPOXY_GET_PROC.store(*get as usize as *mut c_void, Ordering::Relaxed);

--- a/apps/tv-tauri/src-tauri/src/render_linux.rs
+++ b/apps/tv-tauri/src-tauri/src/render_linux.rs
@@ -1,0 +1,238 @@
+//! Linux video embedding via mpv's **render API** (soia's architecture; plezy's open GL recipe),
+//! mirroring `render_macos.rs`.
+//!
+//! Like macOS — and UNLIKE Windows — we do NOT hand mpv a `wid`. mpv never owns a window here. Instead
+//! we run `vo=libmpv`, insert a GTK `GLArea` BEHIND the transparent WebKitGTK webview (via a `GtkOverlay`),
+//! create an `mpv_render_context` (OpenGL), and render each mpv frame into the GLArea's framebuffer. GTK/GDK
+//! owns the actual GL (EGL) context, so this is windowing-agnostic and works on Wayland natively (and under
+//! XWayland). The Wayland/X11 *display* handle is passed to the render context ONLY for VAAPI hw-decode, not
+//! for output.
+//!
+//! ⚠️ UNVALIDATED on hardware. The mpv-render half is a direct translation of plezy
+//! (`.refs/plezy/linux/runner/mpv/`); the GLArea-behind-webview compositing is the part that needs on-device
+//! iteration (Omarchy/Hyprland/Wayland). Two risk points are flagged inline: (1) reparenting Tauri's GTK
+//! child into a GtkOverlay, and (2) reading the GLArea's bound FBO id. See `.plans/tv-tauri-linux-render.md`.
+
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int, c_void};
+use std::ptr;
+use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::Arc;
+
+use gtk::glib::translate::ToGlibPtr;
+use gtk::prelude::*;
+
+use crate::mpv::{self, ffi};
+
+// ── GL proc resolution (epoxy) ───────────────────────────────────────────────
+// mpv resolves each GL symbol it needs through this. GTK links libepoxy, so its loader hands back the
+// live GL/GLES entry points for whatever context GDK created (EGL on Wayland).
+extern "C" fn get_proc_address(_ctx: *mut c_void, name: *const c_char) -> *mut c_void {
+    let Ok(s) = (unsafe { CStr::from_ptr(name) }).to_str() else {
+        return ptr::null_mut();
+    };
+    epoxy::get_proc_addr(s) as *mut c_void
+}
+
+// The live mpv render context, so the GLArea's `render` closure (main thread) can draw with it. Only ever
+// touched on the GTK main thread after setup; stored as a raw pointer so the closures can capture it Copy.
+static RENDER_CTX: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
+
+/// Loaded once: `glGetIntegerv`, so we can read the FBO id GTK bound before calling our `render` closure.
+type GlGetIntegerv = extern "C" fn(pname: c_int, params: *mut c_int);
+static GL_GET_INTEGERV: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
+const GL_DRAW_FRAMEBUFFER_BINDING: c_int = 0x8CA6;
+
+fn current_fbo() -> c_int {
+    let f = GL_GET_INTEGERV.load(Ordering::Relaxed);
+    if f.is_null() {
+        return 0;
+    }
+    // SAFETY: `f` is `glGetIntegerv` resolved via epoxy; called on the GTK render (main) thread.
+    let get: GlGetIntegerv = unsafe { std::mem::transmute(f) };
+    let mut fbo: c_int = 0;
+    get(GL_DRAW_FRAMEBUFFER_BINDING, &mut fbo);
+    fbo
+}
+
+/// Render one mpv frame into the framebuffer GTK bound for this `GLArea::render` pass. Runs on the GTK main
+/// thread inside the `render` signal.
+fn render(area: &gtk::GLArea) {
+    let ctx = RENDER_CTX.load(Ordering::Acquire);
+    if ctx.is_null() {
+        return;
+    }
+    let scale = area.scale_factor().max(1);
+    let w = area.allocated_width() * scale;
+    let h = area.allocated_height() * scale;
+    if w <= 0 || h <= 0 {
+        return;
+    }
+    let mut fbo = ffi::MpvOpenglFbo {
+        fbo: current_fbo(),
+        w,
+        h,
+        internal_format: 0, // SDR 8-bit for now; RGBA16F HDR passthrough is a later pass (see macOS).
+    };
+    // GTK's GLArea framebuffer is already top-left origin like mpv expects, so no Y-flip (plezy uses 0 too).
+    let mut flip: c_int = 0;
+    let mut params = [
+        ffi::MpvRenderParam {
+            type_: ffi::MPV_RENDER_PARAM_OPENGL_FBO,
+            data: &mut fbo as *mut _ as *mut c_void,
+        },
+        ffi::MpvRenderParam {
+            type_: ffi::MPV_RENDER_PARAM_FLIP_Y,
+            data: &mut flip as *mut _ as *mut c_void,
+        },
+        ffi::MpvRenderParam {
+            type_: ffi::MPV_RENDER_PARAM_INVALID,
+            data: ptr::null_mut(),
+        },
+    ];
+    unsafe { ffi::mpv_render_context_render(ctx, params.as_mut_ptr()) };
+}
+
+/// mpv's render-update callback — fires (possibly off the GTK thread) when a new frame is ready. We must
+/// NOT touch GTK from here; bounce to the main loop and `queue_render`. `data` is the leaked GLArea ptr's
+/// weak-ish handle via a channel sender (see setup). Kept minimal: it just wakes the main loop.
+extern "C" fn on_update(data: *mut c_void) {
+    if data.is_null() {
+        return;
+    }
+    // SAFETY: `data` is a leaked `glib::Sender<()>` living for the app lifetime.
+    let tx = unsafe { &*(data as *const gtk::glib::Sender<()>) };
+    let _ = tx.send(());
+}
+
+/// Insert a GLArea behind the transparent webview, create mpv's OpenGL render context, and wire the render
+/// pump. Call AFTER `mpv_initialize` (with `vo=libmpv`), on the main thread (Tauri `setup`).
+pub fn setup(window: &tauri::WebviewWindow, mpv: &Arc<mpv::Mpv>) -> Result<(), String> {
+    // Load libepoxy so both mpv's get_proc_address and our glGetIntegerv resolve to the live GL entry
+    // points. GTK already links epoxy; we just point the crate's loader at it.
+    {
+        use libloading::os::unix::Library;
+        // RTLD_DEFAULT-style: epoxy is already in-process (GTK linked it); open with the SONAME.
+        let lib = Library::new("libepoxy.so.0").or_else(|_| Library::new("libepoxy.so")).map_err(|e| e.to_string())?;
+        epoxy::load_with(|name| unsafe {
+            lib.get::<*const c_void>(name.as_bytes()).map(|s| *s).unwrap_or(ptr::null())
+        });
+        // Cache glGetIntegerv for the FBO read.
+        GL_GET_INTEGERV.store(epoxy::get_proc_addr("glGetIntegerv") as *mut c_void, Ordering::Relaxed);
+        // Leak the library handle for the app lifetime.
+        std::mem::forget(lib);
+    }
+
+    let gtk_window = window.gtk_window().map_err(|e| e.to_string())?;
+
+    // ⚠️ RISK 1 — compositing: Tauri's GTK window holds the WebKitGTK webview as its child. We move that
+    // child into a GtkOverlay with a GLArea as the overlay's BASE (so the video is behind) and the webview
+    // as the overlay child (transparent, so the HTML player composites over the video). The draft PR warned
+    // that wrapper-widget reparenting can trigger an undecorated-resize panic; if so, the fallback is a
+    // wl_subsurface below the webview (soia's model) instead of a GTK overlay. Validate on device.
+    let child = gtk_window.child().ok_or("Tauri GTK window has no child to reparent")?;
+    gtk_window.remove(&child);
+    let overlay = gtk::Overlay::new();
+    let gl_area = gtk::GLArea::new();
+    gl_area.set_hexpand(true);
+    gl_area.set_vexpand(true);
+    // mpv gpu/gpu-next want a modern context; GLArea defaults to desktop GL 3.2+ where available. Leave the
+    // GDK default (do not force ES) so we get the best context the compositor offers.
+    gl_area.set_has_depth_buffer(false);
+    gl_area.set_has_stencil_buffer(false);
+    overlay.add(&gl_area); // base layer (video)
+    overlay.add_overlay(&child); // the webview, on top
+    overlay.set_overlay_pass_through(&child, false);
+    gtk_window.add(&overlay);
+    overlay.show_all();
+
+    // A main-thread channel: mpv's update callback (any thread) sends; the receiver queues a GLArea redraw.
+    let (tx, rx) = gtk::glib::MainContext::channel::<()>(gtk::glib::Priority::default());
+    {
+        let area = gl_area.clone();
+        rx.attach(None, move |_| {
+            area.queue_render();
+            gtk::glib::Continue(true)
+        });
+    }
+    // Leak the sender so its pointer stays valid for the update callback for the app lifetime.
+    let tx_ptr = Box::into_raw(Box::new(tx)) as *mut c_void;
+
+    // Create the mpv render context when the GLArea's GL context is realized (GL must be current). Capture
+    // the mpv ctx handle + display handles for VAAPI.
+    let mpv_ctx = mpv.ctx_raw();
+    let wl_display = wayland_display_ptr(&gtk_window);
+    let x11_display = x11_display_ptr(&gtk_window);
+    gl_area.connect_realize(move |area| {
+        area.make_current();
+        if let Err(e) = area.error() {
+            log::error!("GLArea realize error: {e}");
+            return;
+        }
+        let mut init = ffi::MpvOpenglInitParams {
+            get_proc_address,
+            get_proc_address_ctx: ptr::null_mut(),
+        };
+        let mut params = vec![
+            ffi::MpvRenderParam {
+                type_: ffi::MPV_RENDER_PARAM_API_TYPE,
+                data: ffi::MPV_RENDER_API_TYPE_OPENGL.as_ptr() as *mut c_void,
+            },
+            ffi::MpvRenderParam {
+                type_: ffi::MPV_RENDER_PARAM_OPENGL_INIT_PARAMS,
+                data: &mut init as *mut _ as *mut c_void,
+            },
+        ];
+        // Display handle for VAAPI hw-decode only (NOT output). Prefer Wayland, else X11.
+        let mut wl = wl_display;
+        let mut x11 = x11_display;
+        if !wl.is_null() {
+            params.push(ffi::MpvRenderParam { type_: ffi::MPV_RENDER_PARAM_WL_DISPLAY, data: &mut wl as *mut _ as *mut c_void });
+        } else if !x11.is_null() {
+            params.push(ffi::MpvRenderParam { type_: ffi::MPV_RENDER_PARAM_X11_DISPLAY, data: &mut x11 as *mut _ as *mut c_void });
+        }
+        params.push(ffi::MpvRenderParam { type_: ffi::MPV_RENDER_PARAM_INVALID, data: ptr::null_mut() });
+
+        let mut ctx: *mut c_void = ptr::null_mut();
+        let rc = unsafe { ffi::mpv_render_context_create(&mut ctx, mpv_ctx, params.as_mut_ptr()) };
+        if rc < 0 || ctx.is_null() {
+            log::error!("mpv_render_context_create failed: {rc}");
+            return;
+        }
+        RENDER_CTX.store(ctx, Ordering::Release);
+        unsafe { ffi::mpv_render_context_set_update_callback(ctx, on_update, tx_ptr) };
+        log::info!("Linux render context up (GLArea)");
+    });
+
+    gl_area.connect_render(move |area, _ctx| {
+        render(area);
+        gtk::Inhibit(true)
+    });
+
+    Ok(())
+}
+
+/// Best-effort resize hook. GLArea reallocates its own framebuffer on size/scale changes and re-renders,
+/// and our `render()` reads the live allocation each pass — so there's nothing mpv-side to do. Kept for
+/// symmetry with `render_macos::on_resize` and in case a future path needs an explicit refit.
+pub fn on_resize(_window: &tauri::WebviewWindow) {}
+
+// ── Display-handle extraction (VAAPI only) ───────────────────────────────────
+// Pull the raw `wl_display` / X11 `Display*` from the GTK window's GDK display, so mpv's VAAPI decoder can
+// reach the GPU. Returns null when the other backend is in use. These use gdk backend downcasts guarded so
+// a mismatched session just yields null (mpv then decodes without that VAAPI hint).
+fn wayland_display_ptr(gtk_window: &gtk::ApplicationWindow) -> *mut c_void {
+    let Some(display) = gtk_window.display().dynamic_cast_ref::<gdkwayland::WaylandDisplay>().cloned() else {
+        return ptr::null_mut();
+    };
+    // SAFETY: FFI to gdk_wayland_display_get_wl_display on a confirmed Wayland display.
+    unsafe { gdkwayland::ffi::gdk_wayland_display_get_wl_display(display.to_glib_none().0) as *mut c_void }
+}
+
+fn x11_display_ptr(gtk_window: &gtk::ApplicationWindow) -> *mut c_void {
+    let Some(display) = gtk_window.display().dynamic_cast_ref::<gdkx11::X11Display>().cloned() else {
+        return ptr::null_mut();
+    };
+    // SAFETY: FFI to gdk_x11_display_get_xdisplay on a confirmed X11 display.
+    unsafe { gdkx11::ffi::gdk_x11_display_get_xdisplay(display.to_glib_none().0) as *mut c_void }
+}

--- a/apps/tv-tauri/src-tauri/src/render_linux.rs
+++ b/apps/tv-tauri/src-tauri/src/render_linux.rs
@@ -160,7 +160,7 @@ pub fn setup(window: &tauri::WebviewWindow, mpv: &Arc<mpv::Mpv>) -> Result<(), S
         let area = gl_area.clone();
         rx.attach(None, move |_| {
             area.queue_render();
-            gtk::glib::Continue(true)
+            gtk::glib::ControlFlow::Continue
         });
     }
     // Leak the sender so its pointer stays valid for the update callback for the app lifetime.
@@ -173,7 +173,7 @@ pub fn setup(window: &tauri::WebviewWindow, mpv: &Arc<mpv::Mpv>) -> Result<(), S
     let x11_display = x11_display_ptr(&gtk_window);
     gl_area.connect_realize(move |area| {
         area.make_current();
-        if let Err(e) = area.error() {
+        if let Some(e) = area.error() {
             log::error!("GLArea realize error: {e}");
             return;
         }
@@ -214,7 +214,7 @@ pub fn setup(window: &tauri::WebviewWindow, mpv: &Arc<mpv::Mpv>) -> Result<(), S
 
     gl_area.connect_render(move |area, _ctx| {
         render(area);
-        gtk::Inhibit(true)
+        gtk::glib::Propagation::Stop
     });
 
     Ok(())

--- a/apps/tv-tauri/src-tauri/src/render_linux.rs
+++ b/apps/tv-tauri/src-tauri/src/render_linux.rs
@@ -47,16 +47,17 @@ type EGLSurface = *mut c_void;
 const EGL_PLATFORM_WAYLAND_KHR: u32 = 0x31D8;
 const EGL_OPENGL_API: u32 = 0x30A2;
 const EGL_NO_CONTEXT: EGLContext = ptr::null_mut();
-const EGL_NONE: isize = 0x3038;
-const EGL_SURFACE_TYPE: isize = 0x3033;
-const EGL_WINDOW_BIT: isize = 0x0004;
-const EGL_RENDERABLE_TYPE: isize = 0x3040;
-const EGL_OPENGL_BIT: isize = 0x0008;
-const EGL_RED_SIZE: isize = 0x3024;
-const EGL_GREEN_SIZE: isize = 0x3023;
-const EGL_BLUE_SIZE: isize = 0x3022;
-const EGL_ALPHA_SIZE: isize = 0x3021;
-const EGL_CONTEXT_MAJOR_VERSION: isize = 0x3098;
+// EGL attribute lists (eglChooseConfig/eglCreateContext/eglCreateWindowSurface) are EGLint = 32-bit.
+const EGL_NONE: c_int = 0x3038;
+const EGL_SURFACE_TYPE: c_int = 0x3033;
+const EGL_WINDOW_BIT: c_int = 0x0004;
+const EGL_RENDERABLE_TYPE: c_int = 0x3040;
+const EGL_OPENGL_BIT: c_int = 0x0008;
+const EGL_RED_SIZE: c_int = 0x3024;
+const EGL_GREEN_SIZE: c_int = 0x3023;
+const EGL_BLUE_SIZE: c_int = 0x3022;
+const EGL_ALPHA_SIZE: c_int = 0x3021;
+const EGL_CONTEXT_MAJOR_VERSION: c_int = 0x3098;
 
 #[link(name = "EGL")]
 extern "C" {
@@ -69,7 +70,7 @@ extern "C" {
     fn eglBindAPI(api: u32) -> u32;
     fn eglChooseConfig(
         dpy: EGLDisplay,
-        attribs: *const isize,
+        attribs: *const c_int,
         configs: *mut EGLConfig,
         size: i32,
         num: *mut i32,
@@ -78,13 +79,13 @@ extern "C" {
         dpy: EGLDisplay,
         config: EGLConfig,
         share: EGLContext,
-        attribs: *const isize,
+        attribs: *const c_int,
     ) -> EGLContext;
     fn eglCreateWindowSurface(
         dpy: EGLDisplay,
         config: EGLConfig,
         win: *mut c_void,
-        attribs: *const isize,
+        attribs: *const c_int,
     ) -> EGLSurface;
     fn eglMakeCurrent(dpy: EGLDisplay, draw: EGLSurface, read: EGLSurface, ctx: EGLContext) -> u32;
     fn eglSwapBuffers(dpy: EGLDisplay, surface: EGLSurface) -> u32;
@@ -257,7 +258,7 @@ pub fn setup(window: &tauri::WebviewWindow, mpv: &Arc<mpv::Mpv>) -> Result<(), S
     if unsafe { eglBindAPI(EGL_OPENGL_API) } == 0 {
         return Err(format!("eglBindAPI failed: 0x{:x}", egl_err()));
     }
-    let cfg_attribs: [isize; 13] = [
+    let cfg_attribs: [c_int; 13] = [
         EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
         EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
         EGL_RED_SIZE, 8,
@@ -273,7 +274,7 @@ pub fn setup(window: &tauri::WebviewWindow, mpv: &Arc<mpv::Mpv>) -> Result<(), S
     {
         return Err(format!("eglChooseConfig failed: 0x{:x}", egl_err()));
     }
-    let ctx_attribs: [isize; 3] = [EGL_CONTEXT_MAJOR_VERSION, 3, EGL_NONE];
+    let ctx_attribs: [c_int; 3] = [EGL_CONTEXT_MAJOR_VERSION, 3, EGL_NONE];
     let egl_ctx = unsafe { eglCreateContext(dpy, config, EGL_NO_CONTEXT, ctx_attribs.as_ptr()) };
     if egl_ctx.is_null() {
         return Err(format!("eglCreateContext failed: 0x{:x}", egl_err()));

--- a/apps/tv-tauri/src-tauri/tauri.conf.json
+++ b/apps/tv-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Airwave Client",
-  "version": "0.13.37",
+  "version": "0.13.39",
   "identifier": "com.airwave.tvdesktop",
   "build": {
     "frontendDist": "../dist",

--- a/apps/tv-tauri/src-tauri/tauri.linux.conf.json
+++ b/apps/tv-tauri/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "title": "Airwave",
+        "width": 1280,
+        "height": 720,
+        "minWidth": 960,
+        "minHeight": 540,
+        "resizable": true,
+        "center": true,
+        "fullscreen": false,
+        "decorations": false,
+        "transparent": true
+      }
+    ]
+  },
+  "bundle": {
+    "targets": ["appimage"],
+    "resources": {
+      "vendor/libmpv/linux-x64/lib/*.so*": ""
+    }
+  }
+}

--- a/apps/tv-web/package.json
+++ b/apps/tv-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv-web",
-  "version": "0.13.37",
+  "version": "0.13.39",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/tv-web/public/appinfo.json
+++ b/apps/tv-web/public/appinfo.json
@@ -1,6 +1,6 @@
 {
   "id": "com.airwave.tv",
-  "version": "0.13.37",
+  "version": "0.13.39",
   "vendor": "Airwave",
   "type": "web",
   "main": "index.html",

--- a/apps/tv-web/public/config.xml
+++ b/apps/tv-web/public/config.xml
@@ -10,7 +10,7 @@
   of Samsung TVs (raise it only to use newer TV web APIs). NB: XML comments must not contain a double
   hyphen, so avoid CLI flags here.
 -->
-<widget xmlns="http://www.w3.org/ns/widgets" xmlns:tizen="http://tizen.org/ns/widgets" id="http://com.airwave.tv/Airwave" version="0.13.37" viewmodes="maximized">
+<widget xmlns="http://www.w3.org/ns/widgets" xmlns:tizen="http://tizen.org/ns/widgets" id="http://com.airwave.tv/Airwave" version="0.13.39" viewmodes="maximized">
   <tizen:application id="Airwavetv1.Airwave" package="Airwavetv1" required_version="2.4"/>
   <tizen:profile name="tv"/>
   <name>Airwave</name>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.13.37",
+  "version": "0.13.39",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tools/libmpv/build-ffmpeg.sh
+++ b/tools/libmpv/build-ffmpeg.sh
@@ -212,8 +212,9 @@ if [ "$TARGET_OS" = "linux" ]; then
     # Linux has NO OS-native TLS. configure auto-enables SChannel on Windows and SecureTransport on macOS,
     # so those get https for free — but on Linux, without OpenSSL/GnuTLS there is no `tls`/`https` protocol
     # at all, and every mpv fetch of an https URL fails (the "all transcode on Linux" symptom). Enable
-    # OpenSSL (3.x is Apache-2.0 = GPL-compatible, no --enable-nonfree needed). Needs libssl-dev at build.
-    CONFIGURE_ARGS+=( --enable-openssl )
+    # OpenSSL (3.x is Apache-2.0 = GPL-compatible). FFmpeg requires --enable-version3 to link OpenSSL >=3.0
+    # (upgrades the build's license to GPLv3, fine — libmpv is already GPL). Needs libssl-dev at build.
+    CONFIGURE_ARGS+=( --enable-version3 --enable-openssl )
 else
     # Windows (SChannel) / macOS (SecureTransport) use the OS-native TLS; keep OpenSSL out of the build.
     CONFIGURE_ARGS+=( --disable-openssl )

--- a/tools/libmpv/build-ffmpeg.sh
+++ b/tools/libmpv/build-ffmpeg.sh
@@ -187,7 +187,6 @@ CONFIGURE_ARGS=(
     --disable-debug
     --disable-doc
     --disable-programs
-    --disable-openssl
     --disable-encoders
     --enable-encoder=mjpeg
     --disable-muxers
@@ -206,6 +205,18 @@ if [ "$TARGET_OS" != "mingw32" ]; then
     CONFIGURE_ARGS+=(
         --enable-pic
     )
+fi
+
+# TLS backend for https:// (server clip URLs + Plex streams).
+if [ "$TARGET_OS" = "linux" ]; then
+    # Linux has NO OS-native TLS. configure auto-enables SChannel on Windows and SecureTransport on macOS,
+    # so those get https for free — but on Linux, without OpenSSL/GnuTLS there is no `tls`/`https` protocol
+    # at all, and every mpv fetch of an https URL fails (the "all transcode on Linux" symptom). Enable
+    # OpenSSL (3.x is Apache-2.0 = GPL-compatible, no --enable-nonfree needed). Needs libssl-dev at build.
+    CONFIGURE_ARGS+=( --enable-openssl )
+else
+    # Windows (SChannel) / macOS (SecureTransport) use the OS-native TLS; keep OpenSSL out of the build.
+    CONFIGURE_ARGS+=( --disable-openssl )
 fi
 
 echo "Configuring FFmpeg with prefix=$FFMPEG_PREFIX"


### PR DESCRIPTION
## What & why

Adds the remaining desktop target — **Linux** — to `apps/tv-tauri`, done the way macOS was solved: the mpv **render API** (`vo=libmpv` + `mpv_render_context`, **no `wid`**), not the X11 `wid` embedding of the earlier draft PR. Architecture proven by soia (Wayland + render API); the concrete GL code is translated from plezy's open Linux runner (soia's own GL glue is a closed `.so`).

## Approach
- **`render_linux.rs`** (new) mirrors `render_macos.rs`: a GTK **GLArea** inserted **behind the transparent WebKitGTK webview** (via a `GtkOverlay`); `mpv_render_context` created on GLArea realize (`get_proc_address` via epoxy); mpv renders into the GLArea's FBO each frame; the pump is mpv's update callback bounced to the GTK main loop (`queue_render`). The Wayland/X11 display handle is passed **only for VAAPI**, never for output.
- **`lib.rs`**: explicit **3-way** video attach (`windows` wid / `macos` render / `linux` render) + a Linux resize hook; dead `resolve_video_wid` stub removed.
- **`mpv/ffi.rs`**: `X11_DISPLAY`/`WL_DISPLAY` render params.
- **`tauri.linux.conf.json`**: borderless + transparent window (so the existing `TitleBar` `!IS_MAC` custom-controls path is used, identical to Windows), **AppImage** bundle (runs on Arch/Omarchy).
- **`Cargo.toml`**: Linux deps (`gtk 0.18` to match Tauri, `gdkwayland`/`gdkx11`, `epoxy`, `libloading`).
- **CI**: the `ubuntu-24.04` row now **builds** — installs webkit2gtk/gtk3/epoxy deps, pulls `linux-x64` libmpv from the `libmpv-latest` release, builds the AppImage, uploads it as a workflow artifact. **No updater fragment** yet, so it never touches `latest.json`.

## Status: DRAFT / UNVALIDATED
Written on Windows — I could not compile or run it. The mpv-render half is high-confidence; the **GLArea-behind-WebKitGTK compositing** (the GtkOverlay reparenting + reading the bound FBO) is the part that needs **on-device iteration on Wayland/Hyprland (Omarchy)**. Likely first-pass fixes: gtk-rs 0.18 API details CI surfaces, the GtkOverlay reparent (draft PR warned of an undecorated-resize panic — fallback is a `wl_subsurface`), and the FBO read. `Cargo.lock` updates on the first Linux build.

## How to test
1. Run the **"TV Desktop (tv-tauri) Build & Release"** workflow via **workflow_dispatch on this branch** (leave `release_tag` blank).
2. Fix any compile errors it surfaces (iterate), then download the `airwave-client-ubuntu-24.04-x64` artifact (the `.AppImage`).
3. Run it on Omarchy and iterate on the compositing.

Plan: `.plans/tv-tauri-linux-render.md`.